### PR TITLE
fix: node LTS default, scoped file index cache, clarify screenshotsRoot

### DIFF
--- a/.github/workflows/visual-baseline-publish.yml
+++ b/.github/workflows/visual-baseline-publish.yml
@@ -6,7 +6,7 @@ on:
       node-version:
         required: false
         type: string
-        default: '23'
+        default: '22'
       repo-config-path:
         required: false
         type: string

--- a/.github/workflows/visual-pr-diff.yml
+++ b/.github/workflows/visual-pr-diff.yml
@@ -6,7 +6,7 @@ on:
       node-version:
         required: false
         type: string
-        default: '23'
+        default: '22'
       repo-config-path:
         required: false
         type: string

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -17,7 +17,7 @@ The shared layer reads runtime visual regression behavior from `.github/visual-r
 | `readyTimeoutSeconds` | `number` | Max seconds to wait for readiness (consumer-owned) |
 | `resultsFile` | `string` | Path (relative to `workingDirectory`) for capture results JSON |
 | `manifestFile` | `string` | Path (relative to `workingDirectory`) for screenshot manifest JSON |
-| `screenshotsRoot` | `string` | Path (relative to `workingDirectory`) for captured screenshot directory |
+| `screenshotsRoot` | `string` | Parent directory for screenshot output (relative to `workingDirectory`); actual PNGs are written to `{screenshotsRoot}/screenshots/{id}.png` |
 | `routes` | `array` | List of route entries to capture |
 | `diff.threshold` | `number` | Max allowed mismatch ratio per screenshot (e.g. `0.01` = 1%) |
 | `diff.mode` | `string` | One of: `report-only`, `fail-on-changes`, `fail-on-incomplete`, `strict` |

--- a/lib/capture-visual-routes.mjs
+++ b/lib/capture-visual-routes.mjs
@@ -137,6 +137,8 @@ export async function runVisualBaselineCapture(options = {}) {
   const manifestPath = resolveFromWorkingDirectory(config, config.manifestFile);
   const screenshotsRoot = resolveFromWorkingDirectory(config, config.screenshotsRoot);
 
+  // Screenshots are written to a `screenshots/` subdirectory inside screenshotsRoot,
+  // i.e. the actual PNG files land at `{screenshotsRoot}/screenshots/{id}.png`.
   await Promise.all([
     ensureParentDirectory(resultsPath),
     ensureParentDirectory(manifestPath),

--- a/lib/compare-visual-results.mjs
+++ b/lib/compare-visual-results.mjs
@@ -406,6 +406,8 @@ export function formatVisualDiffFailureMessage(diffMode, summary) {
  * @returns {Promise<{ summary: VisualDiffSummary, markdown: string }>}
  */
 export async function generateVisualDiffReport(options = {}) {
+  fileIndexCache.clear();
+
   const { config } = await loadVisualRegressionConfig(options.configPath);
   const selectedRouteIds = selectConfiguredRoutes(
     config,


### PR DESCRIPTION
## Summary

Three medium-priority audit fixes:

- **Node v23 → v22 (LTS)** — Both reusable workflow templates (`visual-baseline-publish.yml`, `visual-pr-diff.yml`) defaulted to `node-version: '23'`, a non-LTS release. Changed to `'22'` to match what CI actually tests on and what `package.json` `engines` recommends (`>=20`). Consumers can still override via the `node-version` input.

- **`fileIndexCache` scoped to each report call** — The module-level `Map` in `compare-visual-results.mjs` was never cleared, so stale directory index entries could persist across `generateVisualDiffReport` calls in long-running processes or test suites sharing the same module instance. Now cleared at the start of each call. Within-call caching (multiple routes sharing the same run directory) is preserved.

- **`screenshotsRoot` semantics clarified** — The config field is described as "captured screenshot directory" but actual PNGs land at `{screenshotsRoot}/screenshots/{id}.png`, not directly inside `screenshotsRoot`. Updated the description in `docs/contracts.md` and added an inline comment in `capture-visual-routes.mjs` at the relevant `mkdir` call. The field name is frozen at v1 so no rename.

## Test plan

- [ ] All 105 tests pass (`npm test`)
- [ ] `node-version` input still accepts an override in consumer workflows
- [ ] Repeated calls to `generateVisualDiffReport` in tests use fresh file index each time

🤖 Generated with [Claude Code](https://claude.com/claude-code)