### PR TITLE
fix: shell quoting in ci.yml, narrow JSDoc type, PR comment on capture failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,5 +33,5 @@ jobs:
         run: |
           for f in actions/*/action.yml; do
             echo "Checking $f ..."
-            python3 -c "import yaml; yaml.safe_load(open('$f'))"
+            python3 -c "import sys, yaml; yaml.safe_load(open(sys.argv[1]))" "$f"
           done

--- a/actions/run-visual-pr-diff/action.yml
+++ b/actions/run-visual-pr-diff/action.yml
@@ -478,7 +478,7 @@ runs:
           cat "$SUMMARY_FILE" >> "$GITHUB_STEP_SUMMARY"
         fi
 
-    - if: inputs.comment-on-pr == 'true'
+    - if: always() && inputs.comment-on-pr == 'true'
       uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
       env:
         PR_NUMBER: ${{ steps.context.outputs.pr_number }}
@@ -492,20 +492,29 @@ runs:
           const path = require('path');
           const { pathToFileURL } = require('url');
 
-          const summaryPath = process.env.SUMMARY_PATH;
-          if (!summaryPath || !fs.existsSync(summaryPath)) {
-            core.warning(`Visual diff summary not found at ${summaryPath || '<missing>'}`);
-            return;
-          }
+          const PR_COMMENT_MARKER = '<!-- pr-visual-diff-summary -->';
 
+          const summaryPath = process.env.SUMMARY_PATH;
           const issueNumber = Number(process.env.PR_NUMBER || context.payload.pull_request?.number || context.issue?.number || '');
           if (!Number.isFinite(issueNumber) || issueNumber <= 0) {
             core.warning('Visual diff PR comment skipped because no pull request number was available.');
             return;
           }
 
+          if (!summaryPath || !fs.existsSync(summaryPath)) {
+            const runUrl = process.env.RUN_URL || '';
+            const body = `${PR_COMMENT_MARKER}\n### ⚠️ Visual Diff — Capture Failed\n\nThe visual diff pipeline did not produce a summary. This usually means the screenshot capture step failed before completing.\n\n[View workflow run](${runUrl}) for details.`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              body
+            });
+            return;
+          }
+
           const modulePath = path.resolve(process.env.ACTION_ROOT, 'lib/visual-diff-pr-comment.mjs');
-          const { buildPrCommentBody, PR_COMMENT_MARKER } = await import(pathToFileURL(modulePath));
+          const { buildPrCommentBody } = await import(pathToFileURL(modulePath));
 
           const summary = JSON.parse(fs.readFileSync(summaryPath, 'utf8'));
           const body = buildPrCommentBody(summary, {

--- a/lib/compare-visual-results.mjs
+++ b/lib/compare-visual-results.mjs
@@ -377,7 +377,7 @@ function makeMarkdown(summaryData) {
 
 /**
  * @param {VisualDiffMode} diffMode
- * @param {Pick<VisualDiffSummary, 'changedScreenshots'>} summary
+ * @param {{ changedScreenshots?: number }} summary
  * @returns {string}
  */
 export function formatVisualDiffFailureMessage(diffMode, summary) {


### PR DESCRIPTION
## Summary

Three low-priority audit fixes:

- **Shell quoting in `ci.yml`** — The action-lint loop passed `$f` via string interpolation inside a Python string literal (`open('$f')`), which silently breaks for any filename containing a single quote. Changed to pass the path as `sys.argv[1]` so the shell handles quoting correctly: `python3 -c "... sys.argv[1]" "$f"`.

- **`formatVisualDiffFailureMessage` JSDoc type widened** — The second parameter was typed as `Pick<VisualDiffSummary, 'changedScreenshots'>`, suggesting all callers must supply that field. Only `fail-on-changes` mode actually reads it; `fail-on-incomplete` and `strict` don't touch the summary object at all. Changed to `{ changedScreenshots?: number }` to accurately reflect usage without breaking any existing caller.

- **PR comment posted on capture failure** — The comment step had no `always()` guard, so a catastrophic capture failure left the PR silent with no indication of what went wrong. Added `always()` to the condition. When no summary file is available, the step now posts a fallback comment (containing the `PR_COMMENT_MARKER` so re-run upsert still works) with a link to the workflow run. The marker is inlined as a constant rather than imported from the lib module, since that module may not have been installed yet in a very early failure scenario.

## Test plan

- [ ] All 105 tests pass (`npm test`)
- [ ] `action-lint` job in CI still validates all action YAMLs correctly
- [ ] On a run where capture fails, a PR comment appears with the failure notice and a run link

🤖 Generated with [Claude Code](https://claude.com/claude-code)