### PR TITLE
chore: drop Node 20 support, require Node 22+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20, 22]
+        node-version: [22]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ NODE_OPTIONS='--experimental-vm-modules' npx jest tests/compare-visual-results.t
 for f in actions/*/action.yml; do python3 -c "import yaml; yaml.safe_load(open('$f'))"; done
 ```
 
-Tests require `--experimental-vm-modules` because the project uses ESM (`"type": "module"`).
+Tests require `--experimental-vm-modules` because the project uses ESM (`"type": "module"`). Node 22+ is required.
 
 ## Architecture
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test": "NODE_OPTIONS='--experimental-vm-modules' jest"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "devDependencies": {
     "jest": "^29.7.0",


### PR DESCRIPTION
## Summary

- `package.json` `engines` updated from `>=20` to `>=22`
- CI matrix reduced from `[20, 22]` to `[22]` — removes the duplicate `CI / test (20)` check on PRs

## Test plan

- [ ] Only one `CI / test (22)` check appears on PRs going forward
- [ ] All 105 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)