### PR TITLE
docs: fix stale references, fill coverage gaps found in audit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ npm test
 NODE_OPTIONS='--experimental-vm-modules' npx jest tests/compare-visual-results.test.js
 
 # Validate action YAML files (as CI does)
-for f in actions/*/action.yml; do python3 -c "import yaml; yaml.safe_load(open('$f'))"; done
+for f in actions/*/action.yml; do python3 -c "import sys, yaml; yaml.safe_load(open(sys.argv[1]))" "$f"; done
 ```
 
 Tests require `--experimental-vm-modules` because the project uses ESM (`"type": "module"`). Node 22+ is required.
@@ -73,4 +73,13 @@ Action steps load `lib/` modules at runtime using `node --input-type=module` wit
 
 ### Testing
 
-Tests in `tests/` use Jest with `"transform": {}` (no transpilation). Tests are unit/contract-level — they do not run Playwright or require a live app. CI runs the suite on Node 20 and 22.
+Tests in `tests/` use Jest with `"transform": {}` (no transpilation). Tests are unit/contract-level — they do not run Playwright or require a live app. CI runs the suite on Node 22.
+
+| Test file | What it covers |
+|-----------|---------------|
+| `visual-diff-smoke.test.js` | Config validation, enforcement modes, viewport/readiness contracts, lib exports, artifact bundle structure |
+| `compare-visual-results.test.js` | Pixel diff logic, dimension mismatch, missing screenshots, file index cache, route scoping |
+| `stage-visual-artifacts.test.js` | Baseline and diff bundle staging |
+| `visual-diff-summary.test.js` | Skipped-summary generation for scope and missing-baseline cases |
+| `visual-diff-pr-comment.test.js` | PR comment body construction |
+| `visual-diff-actions-contract.test.js` | Action YAML structure, wrapper action inputs/outputs, viewport preset contract |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,12 +30,15 @@ npx playwright install --with-deps chromium
 
 ## Running Tests
 
-From the parent repo (while this module is still embedded):
-
 ```bash
-NODE_OPTIONS='--experimental-vm-modules' npx jest scripts/visual-diff-smoke.test.js
-NODE_OPTIONS='--experimental-vm-modules' npx jest scripts/visual-diff-pr-comment.test.js
+# Run the full test suite
+npm test
+
+# Run a single test file
+NODE_OPTIONS='--experimental-vm-modules' npx jest tests/visual-diff-smoke.test.js
 ```
+
+The six test files in `tests/` cover config validation, capture, compare, staging, PR comment generation, and action contract integrity. Tests are unit-level — they do not run Playwright or require a live app.
 
 ## Making Changes
 
@@ -62,7 +65,7 @@ The v1 contracts (config schema, artifact structure, action inputs/outputs, view
 
 - ESM modules (`.mjs`) with `type: "module"` in package.json
 - JSDoc type annotations referencing `types/visual-diff-types.d.ts`
-- No transpilation or bundling — runs directly on Node >= 20
+- No transpilation or bundling — runs directly on Node >= 22
 - Composite GitHub Actions with inline shell or `actions/github-script`
 
 ## License

--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ Use the low-level actions only when you need custom orchestration that the wrapp
 
 The pixel diff engine has the following known limitations:
 
+- **Capture failures appear in `errors[]`, not `missing[]`**: When Playwright fails to navigate to or screenshot a route (e.g. navigation timeout, app not responding), that route's result has `status: 'failed'` in the results JSON and appears in the `errors[]` array of the diff summary — not in `missing[]`. Check the workflow logs for the underlying Playwright error.
 - **Viewport dimension changes skip diff**: When a PR changes page content such that the captured screenshot dimensions differ from the baseline (e.g., adding or removing sections that change page height), pixel-level comparison is skipped for that route. These are reported as "dimension changes" in the summary, not as errors. The recommended workflow is to merge the PR and let the main CI re-capture the baseline with the new dimensions.
 - **Full-page capture dependency**: Screenshot dimensions depend on the full rendered page height at capture time. Any layout change that affects the document height — even outside the visually changed area — will trigger a dimension mismatch for that route.
 - **No sub-region diffing**: The engine compares entire screenshots pixel-by-pixel. There is no support for cropping or masking specific regions before comparison.
@@ -259,3 +260,10 @@ When the module moves to a dedicated repo or cuts a new version:
 **Screenshots have different dimensions**
 - Expected when a PR changes page content such that the captured dimensions differ from the baseline (e.g., adding or removing sections that change page height). Recorded as a "dimension change" in the diff summary; pixel comparison is skipped for that route.
 - Merge the PR and let the main CI re-capture the baseline with the new dimensions.
+
+**Route appears in `errors[]` in the diff summary**
+- The Playwright capture for that route failed (navigation timeout, app not ready, crash). Check the workflow run logs for the full error.
+- Ensure the app is fully started and `baseUrl` is reachable before the action runs.
+
+**`readyUrl` or `readyTimeoutSeconds` seem to be ignored**
+- These fields are read by the reusable workflow templates (`visual-baseline-publish.yml`, `visual-pr-diff.yml`) to drive the app readiness poll. If you are using the composite actions directly (not the reusable templates), you are responsible for implementing the readiness wait in your own workflow steps.

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -13,8 +13,8 @@ The shared layer reads runtime visual regression behavior from `.github/visual-r
 | `baselineArtifactName` | `string` | Name for the uploaded baseline artifact |
 | `workingDirectory` | `string` | Root directory for resolving relative paths |
 | `baseUrl` | `string` | Base URL the running app is reachable at |
-| `readyUrl` | `string` | URL to poll for readiness (consumer-owned) |
-| `readyTimeoutSeconds` | `number` | Max seconds to wait for readiness (consumer-owned) |
+| `readyUrl` | `string` | URL to poll for app readiness. Used by the reusable workflow templates; not read by the `lib/` modules themselves. |
+| `readyTimeoutSeconds` | `number` | Max seconds to wait for the app to become ready. Used by the reusable workflow templates; not read by the `lib/` modules themselves. |
 | `resultsFile` | `string` | Path (relative to `workingDirectory`) for capture results JSON |
 | `manifestFile` | `string` | Path (relative to `workingDirectory`) for screenshot manifest JSON |
 | `screenshotsRoot` | `string` | Parent directory for screenshot output (relative to `workingDirectory`); actual PNGs are written to `{screenshotsRoot}/screenshots/{id}.png` |
@@ -201,3 +201,24 @@ Primary integration path:
 - `actions/run-visual-pr-diff` — end-to-end PR diff pipeline
 
 The lower-level actions remain available for advanced consumers, but new consumers should prefer the wrapper actions.
+
+## Environment variables (advanced / low-level usage)
+
+The `lib/` modules read the following environment variables as fallbacks when options are not passed programmatically. These are set automatically by the wrapper actions and do not need to be set manually when using `publish-visual-baseline` or `run-visual-pr-diff`. They are documented here for consumers building custom orchestration on top of the low-level actions.
+
+| Variable | Module | Description |
+|:---------|:-------|:------------|
+| `QA_VISUAL_CONFIG_PATH` | `visual-regression-config.mjs` | Override path to `visual-regression.json` |
+| `QA_VISUAL_ROUTE_IDS` | `capture-visual-routes.mjs`, `compare-visual-results.mjs` | Comma-separated route ids to capture/compare |
+| `QA_VISUAL_BASELINE_RESULTS_PATH` | `compare-visual-results.mjs` | Path to baseline `visual-baseline-results.json` |
+| `QA_VISUAL_BASELINE_MANIFEST_PATH` | `compare-visual-results.mjs` | Path to baseline `visual-screenshot-manifest.json` |
+| `QA_VISUAL_CURRENT_RESULTS_PATH` | `compare-visual-results.mjs` | Path to current `visual-baseline-results.json` |
+| `QA_VISUAL_CURRENT_MANIFEST_PATH` | `compare-visual-results.mjs` | Path to current `visual-screenshot-manifest.json` |
+| `QA_VISUAL_BASELINE_RUN_DIR` | `compare-visual-results.mjs` | Root directory for resolving baseline screenshot paths (default: `baseline`) |
+| `QA_VISUAL_CURRENT_RUN_DIR` | `compare-visual-results.mjs` | Root directory for resolving current screenshot paths |
+| `QA_VISUAL_DIFF_OUT_DIR` | `compare-visual-results.mjs` | Output directory for diff summary files (default: `qa-artifacts/visual-diffs/current`) |
+| `QA_VISUAL_DIFF_SUMMARY_PATH` | `compare-visual-results.mjs` | Override path for `visual-diff-summary.json` |
+| `QA_VISUAL_DIFF_SUMMARY_MARKDOWN` | `compare-visual-results.mjs` | Override path for `visual-diff-summary.md` |
+| `QA_VISUAL_BASELINE_ARTIFACT_NAME` | `compare-visual-results.mjs` | Baseline artifact name to embed in the summary |
+| `QA_VISUAL_BASELINE_SOURCE_SHA` | `compare-visual-results.mjs` | Baseline source SHA to embed in the summary |
+| `QA_VISUAL_ENFORCE_OUTCOME` | `compare-visual-results.mjs` | Set to `0` to disable enforcement when running `runVisualDiffCli` directly (default: enforces) |


### PR DESCRIPTION
## Summary

Fixes all findings from the documentation audit across four files.

**`CONTRIBUTING.md`**
- Running Tests section replaced non-existent `scripts/` paths with correct `tests/` paths; added `npm test` as the primary command with a description of the test suite
- Code Style section: `Node >= 20` → `Node >= 22`

**`CLAUDE.md`**
- Action-lint command updated to use `sys.argv[1]` (matches the actual `ci.yml` after the shell-quoting fix from PR #3)
- Testing section: "Node 20 and 22" → "Node 22"; added a table describing what each of the six test files covers

**`README.md`**
- Diff limitations: added bullet explaining capture failures surface in `errors[]` not `missing[]`
- Troubleshooting: added three new entries — route in `errors[]`, `readyUrl` seemingly ignored when using composite actions directly

**`docs/contracts.md`**
- `readyUrl` / `readyTimeoutSeconds` descriptions clarified: used by the reusable workflow templates, not the `lib/` modules
- New **Environment variables** section documents all `QA_VISUAL_*` env vars for consumers building custom orchestration on the low-level actions

## Test plan

- [ ] All 105 tests pass (`npm test`)
- [ ] No functional code changed — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)