### PR TITLE
Support any app stack: self-provision Node in wrapper actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- (no changes yet)
+- `publish-visual-baseline` and `run-visual-pr-diff` now self-provision Node 22 via `actions/setup-node`; consumer workflows no longer need to set up Node for SnapDrift to work, enabling non-Node app stacks (Python, Go, Ruby, etc.) on Ubuntu runners
 
 ## v1.0.0
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ SnapDrift captures full-page screenshots of your app on every push to `main`, th
 - **PR comments** — structured summary posted and updated automatically on the PR
 - **Enforcement** — fails the build if screenshots change, depending on your chosen mode
 
-You keep ownership of checkout, Node setup, build, and app startup. SnapDrift takes over once the app is running.
+You keep ownership of checkout, build, and app startup. SnapDrift takes over once the app is running.
 
 ## Quickstart
 
@@ -77,8 +77,7 @@ Start with `report-only` to accumulate baselines without affecting build status.
 
 ## Known limitations
 
-- **Node apps only (v1)** — the runner must have Node 22+ available and the consumer app is expected to be Node-based; non-Node consumers (Python, Go, Ruby, etc.) are not yet supported
-- **Ubuntu runners only (v1)** — Playwright's system dependency installer (`--with-deps`) requires apt; `windows-latest` and `macos-latest` runners are not supported
+- **Ubuntu runners only** — Playwright's system dependency installer (`--with-deps`) requires apt; `windows-latest` and `macos-latest` runners are not supported
 - Full-page capture only — no sub-region masking or cropping
 - Fixed viewport presets: `desktop` (1440×900) and `mobile` (390×844)
 - Single `diff.threshold` applies to all routes — no per-route overrides

--- a/actions/publish-visual-baseline/action.yml
+++ b/actions/publish-visual-baseline/action.yml
@@ -46,6 +46,11 @@ runs:
       shell: bash
       run: echo "ACTION_ROOT=$(cd "$GITHUB_ACTION_PATH/../.." && pwd)" >> "$GITHUB_ENV"
 
+    - name: Set up Node.js
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      with:
+        node-version: '22'
+
     - id: config
       shell: bash
       env:

--- a/actions/run-visual-pr-diff/action.yml
+++ b/actions/run-visual-pr-diff/action.yml
@@ -82,6 +82,11 @@ runs:
       shell: bash
       run: echo "ACTION_ROOT=$(cd "$GITHUB_ACTION_PATH/../.." && pwd)" >> "$GITHUB_ENV"
 
+    - name: Set up Node.js
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      with:
+        node-version: '22'
+
     - id: context
       uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
       env:

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -4,16 +4,16 @@ This guide walks through setting up SnapDrift in a consumer repo from scratch.
 
 ## Prerequisites
 
-> **v1 supports Node-based apps on Ubuntu runners only.**
-> - The runner must have Node 22+ available; SnapDrift uses it internally for its own scripts.
-> - The consumer app is expected to be a Node project. Non-Node consumers (Python, Go, Ruby, etc.) are not yet supported.
+> **v1 supports any app stack on Ubuntu runners.**
+> - SnapDrift self-provisions Node 22 internally — your consumer workflow does not need to set up Node.
+> - The consumer app can be any language or framework (Node, Python, Go, Ruby, etc.). SnapDrift only needs the app to be running and reachable at `baseUrl`.
 > - The runner must be Ubuntu-compatible (`ubuntu-latest` or equivalent). SnapDrift installs Playwright's Chromium and system dependencies via `apt`; `windows-latest` and `macos-latest` runners are not supported in v1.
 > - Playwright Chromium is installed automatically by SnapDrift on each run (~150 MB, takes 1–2 min). No manual Playwright setup is required, but the runner must have outbound network access to reach the Playwright CDN.
 
 Your repo must handle its own:
 
 - Checkout
-- Node setup (≥22) and dependency installation
+- Dependency installation (in whatever language/tool your app uses)
 - App build
 - App startup and readiness wait
 - App shutdown
@@ -83,7 +83,7 @@ Then add the diff step after your app is running:
     repo-config-path: .github/visual-regression.json
 ```
 
-### Complete example workflow
+### Complete example workflow (Node app)
 
 ```yaml
 name: PR Visual Diff
@@ -123,6 +123,49 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           repo-config-path: .github/visual-regression.json
 ```
+
+### Complete example workflow (Python app)
+
+SnapDrift handles its own Node setup, so a Python (or Go, Ruby, etc.) consumer workflow looks identical — just swap out the build/start steps for your stack:
+
+```yaml
+name: PR Visual Diff
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  actions: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  visual-diff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install -r requirements.txt
+
+      - name: Start app
+        run: |
+          gunicorn myapp:app --bind 127.0.0.1:8080 &
+          for i in $(seq 1 45); do
+            curl -sf http://127.0.0.1:8080 && break || sleep 1
+          done
+
+      - name: Run visual PR diff
+        uses: ranacseruet/snapdrift/actions/run-visual-pr-diff@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-config-path: .github/visual-regression.json
+```
+
+No `actions/setup-node` step needed — SnapDrift provisions Node 22 internally.
 
 ### What the wrapper does
 

--- a/tests/visual-diff-actions-contract.test.js
+++ b/tests/visual-diff-actions-contract.test.js
@@ -66,4 +66,18 @@ describe('visual diff action contracts', () => {
         expect(runPrDiff.outputs['summary-path']).toBeTruthy();
         expect(runPrDiff.outputs['bundle-dir']).toBeTruthy();
     });
+
+    it('wrapper actions self-provision Node so non-Node consumers do not need to', async () => {
+        const publishBaseline = await readAction('actions/publish-visual-baseline/action.yml');
+        const runPrDiff = await readAction('actions/run-visual-pr-diff/action.yml');
+
+        function hasSetupNodeStep(action) {
+            return (action.runs?.steps || []).some(
+                (step) => typeof step.uses === 'string' && step.uses.startsWith('actions/setup-node@')
+            );
+        }
+
+        expect(hasSetupNodeStep(publishBaseline)).toBe(true);
+        expect(hasSetupNodeStep(runPrDiff)).toBe(true);
+    });
 });


### PR DESCRIPTION
## Summary

SnapDrift's wrapper actions implicitly required the consumer workflow to have Node available on the runner — typically because Node-based apps would already run `actions/setup-node` for their own build. Non-Node consumers (Python, Go, Ruby, etc.) wouldn't have Node set up, causing the first `node --input-type=module` invocation inside SnapDrift to fail immediately.

The fix is simple: both wrapper actions (`publish-visual-baseline` and `run-visual-pr-diff`) now call `actions/setup-node@v4` (Node 22) as their second internal step, right after setting `ACTION_ROOT`. This makes SnapDrift fully self-sufficient — the consumer workflow never needs to set up Node for SnapDrift's sake.

Notably, no action inputs changed and no config schema changed. Existing Node-based consumer workflows continue to work unchanged (setup-node is idempotent).

## Changes

- **`actions/publish-visual-baseline/action.yml`** — add `actions/setup-node@v4` step before the first `node` invocation
- **`actions/run-visual-pr-diff/action.yml`** — same
- **`tests/visual-diff-actions-contract.test.js`** — new contract assertion that both wrapper actions contain a `setup-node` step, preventing accidental regression
- **`README.md`** — remove "Node apps only" from Known Limitations; update the ownership line to drop the mention of "Node setup" as consumer responsibility
- **`docs/integration-guide.md`** — rewrite Prerequisites to reflect stack-agnostic support; add a full Python/gunicorn workflow example alongside the existing Node example
- **`CHANGELOG.md`** — note the change under Unreleased

## Test plan

- [x] All 106 existing tests pass (`npm test`)
- [x] New contract test passes: both wrapper action YAMLs contain `actions/setup-node@` step
- [ ] Verify CI passes on this PR (action YAML lint + test suite)
- [ ] Spot-check: confirm a non-Node consumer workflow (e.g. the Python example in the guide) would not need `actions/setup-node` in its steps to use SnapDrift

🤖 Generated with [Claude Code](https://claude.com/claude-code)