### PR TITLE
Rename low-level SnapDrift actions

### DIFF
--- a/actions/capture/action.yml
+++ b/actions/capture/action.yml
@@ -1,4 +1,4 @@
-name: Capture Visual Routes
+name: SnapDrift Capture
 description: Capture configured visual regression routes and emit the standard results and manifest files.
 
 inputs:

--- a/actions/comment/action.yml
+++ b/actions/comment/action.yml
@@ -1,4 +1,4 @@
-name: Publish Visual PR Comment
+name: SnapDrift Comment
 description: Upsert a PR comment with the visual diff summary.
 
 inputs:

--- a/actions/compare/action.yml
+++ b/actions/compare/action.yml
@@ -1,4 +1,4 @@
-name: Compare Visual Results
+name: SnapDrift Compare
 description: Compare the current visual capture against a baseline and emit the standard summary files.
 
 inputs:

--- a/actions/enforce/action.yml
+++ b/actions/enforce/action.yml
@@ -1,4 +1,4 @@
-name: Evaluate Visual Diff Outcome
+name: SnapDrift Enforce
 description: Evaluate the diff summary against diff.mode and fail when required.
 
 inputs:

--- a/actions/resolve-baseline/action.yml
+++ b/actions/resolve-baseline/action.yml
@@ -1,4 +1,4 @@
-name: Resolve Baseline Artifact
+name: SnapDrift Resolve Baseline
 description: Resolve and download the latest successful baseline artifact from main.
 
 inputs:

--- a/actions/scope/action.yml
+++ b/actions/scope/action.yml
@@ -1,4 +1,4 @@
-name: Determine Visual Diff Scope
+name: SnapDrift Scope
 description: Determine whether visual diff should run and which configured routes should be selected for the current change set.
 
 inputs:

--- a/actions/stage/action.yml
+++ b/actions/stage/action.yml
@@ -1,4 +1,4 @@
-name: Stage Visual Artifacts
+name: SnapDrift Stage
 description: Stage baseline or diff artifacts into the standard bundle structure before upload.
 
 inputs:

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -203,13 +203,13 @@ Start with `report-only` to accumulate baselines without affecting build status.
 
 The low-level actions are available for custom orchestration when the wrappers don't cover your use case:
 
-- `actions/capture-visual-routes`
-- `actions/compare-visual-results`
-- `actions/determine-visual-diff-scope`
-- `actions/evaluate-visual-diff-outcome`
-- `actions/publish-visual-pr-comment`
-- `actions/resolve-baseline-artifact`
-- `actions/stage-visual-artifacts`
+- `actions/capture`
+- `actions/compare`
+- `actions/scope`
+- `actions/enforce`
+- `actions/comment`
+- `actions/resolve-baseline`
+- `actions/stage`
 
 ## Upgrading
 

--- a/tests/visual-diff-actions-contract.test.js
+++ b/tests/visual-diff-actions-contract.test.js
@@ -11,11 +11,11 @@ async function readAction(actionPath) {
 
 describe('visual diff action contracts', () => {
     it('keeps the low-level defaulted inputs ergonomic', async () => {
-        const determineScope = await readAction('actions/determine-visual-diff-scope/action.yml');
-        const publishComment = await readAction('actions/publish-visual-pr-comment/action.yml');
-        const compare = await readAction('actions/compare-visual-results/action.yml');
-        const stage = await readAction('actions/stage-visual-artifacts/action.yml');
-        const evaluate = await readAction('actions/evaluate-visual-diff-outcome/action.yml');
+        const determineScope = await readAction('actions/scope/action.yml');
+        const publishComment = await readAction('actions/comment/action.yml');
+        const compare = await readAction('actions/compare/action.yml');
+        const stage = await readAction('actions/stage/action.yml');
+        const evaluate = await readAction('actions/enforce/action.yml');
 
         expect(determineScope.inputs['pr-number'].required).toBe(false);
         expect(publishComment.inputs['pr-number'].required).toBe(false);

--- a/tests/visual-diff-smoke.test.js
+++ b/tests/visual-diff-smoke.test.js
@@ -79,14 +79,14 @@ describe('action YML structural integrity', () => {
     it('covers the expected set of action directories', () => {
         const expected = [
             'baseline',
-            'capture-visual-routes',
-            'compare-visual-results',
-            'determine-visual-diff-scope',
-            'evaluate-visual-diff-outcome',
+            'capture',
+            'comment',
+            'compare',
+            'enforce',
             'pr-diff',
-            'publish-visual-pr-comment',
-            'resolve-baseline-artifact',
-            'stage-visual-artifacts'
+            'resolve-baseline',
+            'scope',
+            'stage'
         ];
         expect(actionDirs.sort()).toEqual(expected.sort());
     });


### PR DESCRIPTION
## Summary
- rename the advanced low-level actions to shorter, consistent directory names
- keep the primary wrappers as baseline and pr-diff
- update integration docs and contract tests to use the new low-level action paths

## New names
- actions/capture
- actions/compare
- actions/scope
- actions/resolve-baseline
- actions/stage
- actions/comment
- actions/enforce

## Verification
- npm test
- validate all actions/*/action.yml files with Python YAML parsing