### PR TITLE
Refine PR comment report metrics

### DIFF
--- a/lib/compare-results.mjs
+++ b/lib/compare-results.mjs
@@ -43,6 +43,8 @@ const markdownPath = path.resolve(
 const baselineArtifactName = readFirstDefinedEnv(['SNAPDRIFT_BASELINE_ARTIFACT_NAME', 'QA_VISUAL_BASELINE_ARTIFACT_NAME']) || '';
 const baselineSourceSha = readFirstDefinedEnv(['SNAPDRIFT_BASELINE_SOURCE_SHA', 'QA_VISUAL_BASELINE_SOURCE_SHA']) || '';
 const shouldEnforceOutcomeFromEnv = readFirstDefinedEnv(['SNAPDRIFT_ENFORCE_OUTCOME', 'QA_VISUAL_ENFORCE_OUTCOME']) !== '0';
+const DEFAULT_SNAPDRIFT_REPO_URL = 'https://github.com/ranacseruet/snapdrift';
+const DEFAULT_SNAPDRIFT_ICON_URL = 'https://raw.githubusercontent.com/ranacseruet/snapdrift/main/assets/snapdrift-logo-icon.png';
 
 const fileIndexCache = new Map();
 
@@ -284,24 +286,25 @@ function makeMarkdown(summaryData) {
   const statusIcon = statusIconMap[status] || '⚠️';
   const statusLabel = statusLabelMap[status] || status;
   const dimensionChanges = summaryData.dimensionChanges || [];
+  const selectedRoutes = summaryData.selectedRoutes?.length || 0;
 
   const lines = [
+    `<img src="${DEFAULT_SNAPDRIFT_ICON_URL}" alt="SnapDrift" width="24" height="24" />`,
+    '',
     `# ${statusIcon} SnapDrift Report — ${statusLabel}`,
+    '',
+    '| Selected routes | Stable captures | Diff mode | Threshold |',
+    '|---------------:|----------------:|:----------|----------:|',
+    `| ${selectedRoutes} | ${summaryData.matchedScreenshots} | \`${summaryData.diffMode}\` | ${summaryData.threshold} |`,
     '',
     '| Signal | Count |',
     '|:-------|------:|',
-    `| Selected routes | ${summaryData.selectedRoutes?.length || 0} |`,
-    `| Stable captures | ${summaryData.matchedScreenshots} |`,
     `| Drift signals | ${summaryData.changedScreenshots} |`,
     `| Missing in baseline | ${summaryData.missingInBaseline} |`,
     `| Missing in current capture | ${summaryData.missingInCurrent} |`,
     `| Dimension shifts | ${dimensionChanges.length} |`,
     `| Errors | ${summaryData.errors.length} |`,
-    '',
-    '| Setting | Value |',
-    '|:--------|:------|',
-    `| Drift mode | \`${summaryData.diffMode}\` |`,
-    `| Threshold | ${summaryData.threshold} |`
+    ''
   ];
 
   const metaItems = [];
@@ -379,6 +382,8 @@ function makeMarkdown(summaryData) {
 
   lines.push('');
   lines.push(`<sub>SnapDrift · baseline results \`${summaryData.baselineResultsPath}\` · current results \`${summaryData.currentResultsPath}\`</sub>`);
+  lines.push('');
+  lines.push(`<div align="right"><sub>Powered by <a href="${DEFAULT_SNAPDRIFT_REPO_URL}">SnapDrift</a></sub></div>`);
 
   return lines.join('\n') + '\n';
 }

--- a/lib/drift-summary.mjs
+++ b/lib/drift-summary.mjs
@@ -6,6 +6,22 @@ import path from 'node:path';
 import { splitCommaList } from './snapdrift-config.mjs';
 
 const DEFAULT_OUT_DIR = path.join('qa-artifacts', 'snapdrift', 'drift', 'current');
+const DEFAULT_SNAPDRIFT_REPO_URL = 'https://github.com/ranacseruet/snapdrift';
+const DEFAULT_SNAPDRIFT_ICON_URL = 'https://raw.githubusercontent.com/ranacseruet/snapdrift/main/assets/snapdrift-logo-icon.png';
+
+const STATUS_ICONS = {
+  clean: '✅',
+  'changes-detected': '🟡',
+  incomplete: '⚠️',
+  skipped: '⏭️'
+};
+
+const STATUS_LABELS = {
+  clean: 'Clean',
+  'changes-detected': 'Drift detected',
+  incomplete: 'Incomplete',
+  skipped: 'Skipped'
+};
 
 /**
  * @param {string} reason
@@ -51,6 +67,14 @@ export function buildDriftSummary(options) {
     ? options.selectedRouteIds
     : splitCommaList(options.selectedRouteIds);
   const message = options.message || description.message;
+  const statusIcon = STATUS_ICONS[status] || '⚠️';
+  const statusLabel = STATUS_LABELS[status] || status;
+  const baselineAvailable = typeof options.baselineAvailable === 'boolean'
+    ? String(options.baselineAvailable)
+    : 'n/a';
+  const currentCapture = options.currentResultsPath
+    ? `\`${options.currentResultsPath}\``
+    : 'n/a';
 
   /** @type {Record<string, unknown>} */
   const summary = {
@@ -68,18 +92,18 @@ export function buildDriftSummary(options) {
   }
 
   const lines = [
-    '# SnapDrift Report',
+    `<img src="${DEFAULT_SNAPDRIFT_ICON_URL}" alt="SnapDrift" width="24" height="24" />`,
     '',
-    `- Status: ${status}`,
-    `- Reason: ${description.markdownReason}`
+    `# ${statusIcon} SnapDrift Report — ${statusLabel}`,
+    '',
+    '| Selected routes | Baseline available | Current capture |',
+    '|---------------:|:-------------------|:----------------|',
+    `| ${selectedRoutes.length} | ${baselineAvailable} | ${currentCapture} |`
   ];
 
-  if (message) {
-    lines.push(`- Details: ${message}`);
-  }
-  if (options.currentResultsPath) {
-    lines.push(`- Current capture: \`${options.currentResultsPath}\``);
-  }
+  lines.push('');
+  lines.push(`> **Reason:** ${description.markdownReason}`);
+  lines.push(`> **Details:** ${message}`);
 
   if (options.reason === 'missing_main_baseline_artifact') {
     lines.push('');
@@ -87,6 +111,9 @@ export function buildDriftSummary(options) {
     lines.push('');
     lines.push('- Publish or refresh a SnapDrift baseline on `main`, then rerun the pull request check.');
   }
+
+  lines.push('');
+  lines.push(`<div align="right"><sub>Powered by <a href="${DEFAULT_SNAPDRIFT_REPO_URL}">SnapDrift</a></sub></div>`);
 
   return {
     summary,

--- a/lib/pr-comment.mjs
+++ b/lib/pr-comment.mjs
@@ -51,16 +51,6 @@ export function buildReportCommentBody(summary, meta = {}) {
   const statusIcon = STATUS_ICONS[status] || '⚠️';
   const statusLabel = STATUS_LABELS[status] || status;
   const iconUrl = resolveUrl(meta.iconUrl, DEFAULT_SNAPDRIFT_ICON_URL);
-  const selectedRoutes = Array.isArray(summary.selectedRoutes)
-    ? String(summary.selectedRoutes.length)
-    : 'all';
-  const stableCaptures = String(summary.matchedScreenshots || 0);
-  const diffMode = typeof summary.diffMode === 'string' && summary.diffMode
-    ? `\`${escapeMarkdown(summary.diffMode)}\``
-    : 'n/a';
-  const threshold = Number.isFinite(summary.threshold)
-    ? String(summary.threshold)
-    : 'n/a';
   const dimensionChanges = /** @type {Array<Record<string, unknown>>} */ (summary.dimensionChanges) || [];
   const errors = /** @type {Array<Record<string, unknown>>} */ (summary.errors) || [];
   const errorCount = (/** @type {unknown[]} */ (summary.errors) || []).length;
@@ -70,10 +60,6 @@ export function buildReportCommentBody(summary, meta = {}) {
     `<img src="${iconUrl}" alt="SnapDrift" width="20" height="20" />`,
     '',
     `## ${statusIcon} SnapDrift Report — ${statusLabel}`,
-    '',
-    '| Selected routes | Stable captures | Diff mode | Threshold |',
-    '|---------------:|----------------:|:----------|----------:|',
-    `| ${selectedRoutes} | ${stableCaptures} | ${diffMode} | ${threshold} |`,
     '',
     '| Signal | Count |',
     '|:-------|------:|',

--- a/tests/compare-results.test.js
+++ b/tests/compare-results.test.js
@@ -737,11 +737,15 @@ describe('generateDriftReport', () => {
 
             const { markdown } = await generateDriftReport({ ...opts, routeIds: [routeId] });
 
+            expect(markdown).toContain('<img src="https://raw.githubusercontent.com/ranacseruet/snapdrift/main/assets/snapdrift-logo-icon.png" alt="SnapDrift" width="24" height="24" />');
             expect(markdown).toContain('SnapDrift Report');
             expect(markdown).toContain('Clean');
+            expect(markdown).toContain('| Selected routes | Stable captures | Diff mode | Threshold |');
+            expect(markdown).toContain('| 1 | 1 | `report-only` | 0.01 |');
             expect(markdown).toContain('## Drift signals');
             expect(markdown).toContain('## Dimension shifts');
             expect(markdown).toContain('## Comparison errors');
+            expect(markdown).toContain('Powered by <a href="https://github.com/ranacseruet/snapdrift">SnapDrift</a>');
         });
 
         it('lists changed screenshots with mismatch details', async () => {

--- a/tests/drift-summary.test.js
+++ b/tests/drift-summary.test.js
@@ -36,9 +36,13 @@ describe('SnapDrift skipped summary helpers', () => {
         });
         expect(path.basename(result.summaryPath)).toBe('summary.json');
         expect(path.basename(result.markdownPath)).toBe('summary.md');
-        expect(markdown).toContain('# SnapDrift Report');
-        expect(markdown).toContain('- Status: skipped');
-        expect(markdown).toContain('- Reason: no drift-relevant changes were detected in this pull request');
+        expect(markdown).toContain('<img src="https://raw.githubusercontent.com/ranacseruet/snapdrift/main/assets/snapdrift-logo-icon.png" alt="SnapDrift" width="24" height="24" />');
+        expect(markdown).toContain('# ⏭️ SnapDrift Report — Skipped');
+        expect(markdown).toContain('| Selected routes | Baseline available | Current capture |');
+        expect(markdown).toContain('| 0 | n/a | n/a |');
+        expect(markdown).toContain('> **Reason:** no drift-relevant changes were detected in this pull request');
+        expect(markdown).toContain('> **Details:** No drift-relevant changes were detected in this pull request.');
+        expect(markdown).toContain('Powered by <a href="https://github.com/ranacseruet/snapdrift">SnapDrift</a>');
     });
 
     it('writes the missing-baseline skipped summary with current run metadata', async () => {
@@ -64,7 +68,7 @@ describe('SnapDrift skipped summary helpers', () => {
             baselineAvailable: false,
             currentResultsPath: '/tmp/current-results.json'
         });
-        expect(markdown).toContain('- Current capture: `/tmp/current-results.json`');
+        expect(markdown).toContain('| 2 | false | `/tmp/current-results.json` |');
         expect(markdown).toContain('## Next action');
     });
 
@@ -82,7 +86,7 @@ describe('SnapDrift skipped summary helpers', () => {
             message: 'snapdrift scope check failed',
             selectedRoutes: []
         });
-        expect(markdown).toContain('- Status: incomplete');
-        expect(markdown).toContain('- Reason: snapdrift scope check failed');
+        expect(markdown).toContain('# ⚠️ SnapDrift Report — Incomplete');
+        expect(markdown).toContain('> **Reason:** snapdrift scope check failed');
     });
 });

--- a/tests/pr-comment.test.js
+++ b/tests/pr-comment.test.js
@@ -16,8 +16,6 @@ describe('buildReportCommentBody', () => {
         changedScreenshots: 0,
         missingInBaseline: 0,
         missingInCurrent: 0,
-        diffMode: 'strict',
-        threshold: 0.01,
         errors: [],
         dimensionChanges: [],
         changed: []
@@ -29,13 +27,12 @@ describe('buildReportCommentBody', () => {
         expect(LEGACY_REPORT_COMMENT_MARKER).toBe('<!-- pr-visual-diff-summary -->');
     });
 
-    it('uses metadata and high-signal tables', () => {
+    it('uses a concise high-signal metrics table', () => {
         const body = buildReportCommentBody(cleanSummary);
-        expect(body).toContain('| Selected routes | Stable captures | Diff mode | Threshold |');
-        expect(body).toContain('| 2 | 2 | `strict` | 0.01 |');
         expect(body).toContain('| Signal | Count |');
         expect(body).toContain('| Drift signals | 0 |');
         expect(body).not.toContain('| Errors |');
+        expect(body).not.toContain('| Selected routes | Stable captures | Diff mode | Threshold |');
     });
 
     it('shows status icon and label in heading', () => {
@@ -58,16 +55,6 @@ describe('buildReportCommentBody', () => {
         });
         expect(body).toContain('⏭️ SnapDrift Report — Skipped');
         expect(body).toContain('> **Note:** No drift-relevant changes.');
-    });
-
-    it('shows fallback metadata values when diff settings are unavailable', () => {
-        const body = buildReportCommentBody({
-            status: 'skipped',
-            selectedRoutes: [],
-            matchedScreenshots: 0,
-            errors: []
-        });
-        expect(body).toContain('| 0 | 0 | n/a | n/a |');
     });
 
     it('includes drift signals in a details section with table', () => {
@@ -161,14 +148,16 @@ describe('buildReportCommentBody', () => {
         expect(body).not.toContain('<details>');
     });
 
-    it('shows selected route count from array length', () => {
+    it('keeps the concise metric table when selected routes are provided', () => {
         const body = buildReportCommentBody({ ...cleanSummary, selectedRoutes: ['a', 'b', 'c'] });
-        expect(body).toContain('| 3 | 2 | `strict` | 0.01 |');
+        expect(body).toContain('| Drift signals | 0 |');
+        expect(body).not.toContain('| Selected routes | Stable captures | Diff mode | Threshold |');
     });
 
-    it('shows "all" when selectedRoutes is not an array', () => {
+    it('keeps the concise metric table when selectedRoutes is omitted', () => {
         const { selectedRoutes: _selectedRoutes, ...noRoutes } = cleanSummary;
         const body = buildReportCommentBody({ ...noRoutes, errors: [] });
-        expect(body).toContain('| all | 2 | `strict` | 0.01 |');
+        expect(body).toContain('| Drift signals | 0 |');
+        expect(body).not.toContain('| Selected routes | Stable captures | Diff mode | Threshold |');
     });
 });


### PR DESCRIPTION
## Summary
- move selected routes and stable captures into a metadata table with diff mode and threshold
- keep the main metrics table focused on high-signal drift outcomes
- replace the aggregate errors metric with actionable error details near the note block

## Testing
- NODE_OPTIONS='--experimental-vm-modules' npx jest tests/pr-comment.test.js