### PR TITLE
Extract @snapdrift/manifest and @snapdrift/compare-core packages

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -24,7 +24,7 @@ export default [
     }
   },
   {
-    files: ['tests/**/*.js'],
+    files: ['tests/**/*.js', 'packages/*/tests/**/*.js'],
     languageOptions: {
       globals: {
         ...globals.node,

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "snapdrift",
       "version": "0.2.1",
       "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "playwright": "^1.59.1",
         "pngjs": "^7.0.0"
@@ -17,6 +20,8 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@snapdrift/compare-core": "workspace:*",
+        "@snapdrift/manifest": "workspace:*",
         "@types/jest": "^30.0.0",
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^25.3.5",
@@ -1302,6 +1307,14 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
       }
+    },
+    "node_modules/@snapdrift/compare-core": {
+      "resolved": "packages/compare-core",
+      "link": true
+    },
+    "node_modules/@snapdrift/manifest": {
+      "resolved": "packages/manifest",
+      "link": true
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
@@ -5239,6 +5252,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/compare-core": {
+      "name": "@snapdrift/compare-core",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "pngjs": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "packages/manifest": {
+      "name": "@snapdrift/manifest",
+      "version": "1.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -34,8 +34,13 @@
   "engines": {
     "node": ">=22"
   },
+  "workspaces": [
+    "packages/*"
+  ],
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@snapdrift/compare-core": "workspace:*",
+    "@snapdrift/manifest": "workspace:*",
     "@types/jest": "^30.0.0",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^25.3.5",
@@ -49,7 +54,8 @@
   "jest": {
     "testEnvironment": "node",
     "testMatch": [
-      "**/tests/**/*.test.js"
+      "<rootDir>/tests/**/*.test.js",
+      "<rootDir>/packages/*/tests/**/*.test.js"
     ],
     "transform": {},
     "coverageThreshold": {

--- a/packages/compare-core/package.json
+++ b/packages/compare-core/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@snapdrift/compare-core",
+  "version": "1.0.0",
+  "description": "Pure pixel-comparison engine for SnapDrift — no I/O, no filesystem, no manifest knowledge",
+  "type": "module",
+  "main": "src/index.mjs",
+  "exports": {
+    ".": "./src/index.mjs"
+  },
+  "types": "types/index.d.ts",
+  "files": [
+    "src/",
+    "types/"
+  ],
+  "engines": {
+    "node": ">=22"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ranacseruet/snapdrift.git",
+    "directory": "packages/compare-core"
+  },
+  "dependencies": {
+    "pngjs": "^7.0.0"
+  }
+}

--- a/packages/compare-core/src/compare.mjs
+++ b/packages/compare-core/src/compare.mjs
@@ -1,0 +1,50 @@
+// @ts-check
+
+import pngjs from 'pngjs';
+
+const { PNG } = pngjs;
+
+/**
+ * Compare two PNG image buffers pixel-by-pixel.
+ * Pure function — no filesystem I/O.
+ *
+ * @param {Buffer} baselineBuffer - Raw PNG buffer for the baseline image.
+ * @param {Buffer} currentBuffer - Raw PNG buffer for the current image.
+ * @returns {import('../types/index.d.ts').CompareBuffersResult}
+ * @throws {Error} If image dimensions differ.
+ */
+export function compareBuffers(baselineBuffer, currentBuffer) {
+  const baselinePng = PNG.sync.read(baselineBuffer);
+  const currentPng = PNG.sync.read(currentBuffer);
+
+  if (baselinePng.width !== currentPng.width || baselinePng.height !== currentPng.height) {
+    throw new Error(
+      `Dimension mismatch: baseline ${baselinePng.width}x${baselinePng.height}, current ${currentPng.width}x${currentPng.height}.`
+    );
+  }
+
+  let differentPixels = 0;
+  for (let index = 0; index < baselinePng.data.length; index += 4) {
+    if (
+      baselinePng.data[index] !== currentPng.data[index] ||
+      baselinePng.data[index + 1] !== currentPng.data[index + 1] ||
+      baselinePng.data[index + 2] !== currentPng.data[index + 2] ||
+      baselinePng.data[index + 3] !== currentPng.data[index + 3]
+    ) {
+      differentPixels += 1;
+    }
+  }
+
+  const totalPixels = baselinePng.width * baselinePng.height;
+  const mismatchRatio = totalPixels === 0 ? 0 : differentPixels / totalPixels;
+
+  return {
+    width: baselinePng.width,
+    height: baselinePng.height,
+    differentPixels,
+    totalPixels,
+    mismatchRatio: Number(mismatchRatio.toFixed(6)),
+    pct: Number(mismatchRatio.toFixed(6)),
+    pixelsChanged: differentPixels
+  };
+}

--- a/packages/compare-core/src/compare.mjs
+++ b/packages/compare-core/src/compare.mjs
@@ -43,8 +43,8 @@ export function compareBuffers(baselineBuffer, currentBuffer) {
     height: baselinePng.height,
     differentPixels,
     totalPixels,
-    mismatchRatio: Number(mismatchRatio.toFixed(6)),
-    pct: Number(mismatchRatio.toFixed(6)),
+    mismatchRatio,
+    pct: mismatchRatio,
     pixelsChanged: differentPixels
   };
 }

--- a/packages/compare-core/src/diff-image.mjs
+++ b/packages/compare-core/src/diff-image.mjs
@@ -11,6 +11,12 @@ const DEFAULT_HIGHLIGHT_COLOR = /** @type {const} */ ([255, 0, 0, 255]);
  * Changed pixels are highlighted with the specified color;
  * unchanged pixels retain their original color.
  *
+ * Note: ignore regions are not yet supported in the diff image.
+ * Pixels inside ignore regions are still highlighted as changed,
+ * so the diff image may visually disagree with
+ * `compareWithIgnoreRegions` metrics. Adding `ignoreRegions`
+ * support (neutral mask overlay) is deferred to Phase 1b.
+ *
  * @param {Buffer} baselineBuffer - Raw PNG buffer for the baseline image.
  * @param {Buffer} currentBuffer - Raw PNG buffer for the current image.
  * @param {import('../types/index.d.ts').DiffImageOptions} [options]

--- a/packages/compare-core/src/diff-image.mjs
+++ b/packages/compare-core/src/diff-image.mjs
@@ -1,0 +1,55 @@
+// @ts-check
+
+import pngjs from 'pngjs';
+
+const { PNG } = pngjs;
+
+const DEFAULT_HIGHLIGHT_COLOR = /** @type {const} */ ([255, 0, 0, 255]);
+
+/**
+ * Generate a visual diff PNG buffer from two image buffers.
+ * Changed pixels are highlighted with the specified color;
+ * unchanged pixels retain their original color.
+ *
+ * @param {Buffer} baselineBuffer - Raw PNG buffer for the baseline image.
+ * @param {Buffer} currentBuffer - Raw PNG buffer for the current image.
+ * @param {import('../types/index.d.ts').DiffImageOptions} [options]
+ * @returns {Buffer} PNG buffer of the diff image.
+ * @throws {Error} If image dimensions differ.
+ */
+export function generateDiffImage(baselineBuffer, currentBuffer, options = {}) {
+  const baselinePng = PNG.sync.read(baselineBuffer);
+  const currentPng = PNG.sync.read(currentBuffer);
+
+  if (baselinePng.width !== currentPng.width || baselinePng.height !== currentPng.height) {
+    throw new Error(
+      `Dimension mismatch: baseline ${baselinePng.width}x${baselinePng.height}, current ${currentPng.width}x${currentPng.height}.`
+    );
+  }
+
+  const [r, g, b, a] = options.highlightColor || DEFAULT_HIGHLIGHT_COLOR;
+
+  const diffPng = new PNG({ width: baselinePng.width, height: baselinePng.height });
+
+  for (let i = 0; i < baselinePng.data.length; i += 4) {
+    const changed =
+      baselinePng.data[i] !== currentPng.data[i] ||
+      baselinePng.data[i + 1] !== currentPng.data[i + 1] ||
+      baselinePng.data[i + 2] !== currentPng.data[i + 2] ||
+      baselinePng.data[i + 3] !== currentPng.data[i + 3];
+
+    if (changed) {
+      diffPng.data[i] = r;
+      diffPng.data[i + 1] = g;
+      diffPng.data[i + 2] = b;
+      diffPng.data[i + 3] = a;
+    } else {
+      diffPng.data[i] = baselinePng.data[i];
+      diffPng.data[i + 1] = baselinePng.data[i + 1];
+      diffPng.data[i + 2] = baselinePng.data[i + 2];
+      diffPng.data[i + 3] = baselinePng.data[i + 3];
+    }
+  }
+
+  return PNG.sync.write(diffPng);
+}

--- a/packages/compare-core/src/ignore-regions.mjs
+++ b/packages/compare-core/src/ignore-regions.mjs
@@ -1,0 +1,77 @@
+// @ts-check
+
+import pngjs from 'pngjs';
+
+const { PNG } = pngjs;
+
+/**
+ * Compare two PNG image buffers, masking out ignore regions before counting differences.
+ * Pixels within ignore regions are excluded from both `totalPixels` and `differentPixels`.
+ *
+ * @param {Buffer} baselineBuffer - Raw PNG buffer for the baseline image.
+ * @param {Buffer} currentBuffer - Raw PNG buffer for the current image.
+ * @param {import('../types/index.d.ts').IgnoreRegion[]} regions - Rectangular regions to ignore.
+ * @returns {import('../types/index.d.ts').CompareBuffersResult}
+ * @throws {Error} If image dimensions differ.
+ */
+export function compareWithIgnoreRegions(baselineBuffer, currentBuffer, regions) {
+  const baselinePng = PNG.sync.read(baselineBuffer);
+  const currentPng = PNG.sync.read(currentBuffer);
+
+  if (baselinePng.width !== currentPng.width || baselinePng.height !== currentPng.height) {
+    throw new Error(
+      `Dimension mismatch: baseline ${baselinePng.width}x${baselinePng.height}, current ${currentPng.width}x${currentPng.height}.`
+    );
+  }
+
+  // Build a boolean mask: true means the pixel is in an ignore region.
+  const width = baselinePng.width;
+  const height = baselinePng.height;
+  const ignored = new Uint8Array(width * height);
+
+  for (const region of regions) {
+    const xStart = Math.max(0, region.x);
+    const yStart = Math.max(0, region.y);
+    const xEnd = Math.min(width, region.x + region.width);
+    const yEnd = Math.min(height, region.y + region.height);
+
+    for (let y = yStart; y < yEnd; y++) {
+      for (let x = xStart; x < xEnd; x++) {
+        ignored[y * width + x] = 1;
+      }
+    }
+  }
+
+  let differentPixels = 0;
+  let totalPixels = 0;
+
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      if (ignored[y * width + x]) {
+        continue;
+      }
+      totalPixels += 1;
+      const i = (y * width + x) * 4;
+      if (
+        baselinePng.data[i] !== currentPng.data[i] ||
+        baselinePng.data[i + 1] !== currentPng.data[i + 1] ||
+        baselinePng.data[i + 2] !== currentPng.data[i + 2] ||
+        baselinePng.data[i + 3] !== currentPng.data[i + 3]
+      ) {
+        differentPixels += 1;
+      }
+    }
+  }
+
+  const mismatchRatio = totalPixels === 0 ? 0 : differentPixels / totalPixels;
+
+  return {
+    width,
+    height,
+    differentPixels,
+    totalPixels,
+    mismatchRatio: Number(mismatchRatio.toFixed(6)),
+    pct: Number(mismatchRatio.toFixed(6)),
+    pixelsChanged: differentPixels
+  };
+}

--- a/packages/compare-core/src/ignore-regions.mjs
+++ b/packages/compare-core/src/ignore-regions.mjs
@@ -70,8 +70,8 @@ export function compareWithIgnoreRegions(baselineBuffer, currentBuffer, regions)
     height,
     differentPixels,
     totalPixels,
-    mismatchRatio: Number(mismatchRatio.toFixed(6)),
-    pct: Number(mismatchRatio.toFixed(6)),
+    mismatchRatio,
+    pct: mismatchRatio,
     pixelsChanged: differentPixels
   };
 }

--- a/packages/compare-core/src/index.mjs
+++ b/packages/compare-core/src/index.mjs
@@ -1,0 +1,5 @@
+// @ts-check
+
+export { compareBuffers } from './compare.mjs';
+export { generateDiffImage } from './diff-image.mjs';
+export { compareWithIgnoreRegions } from './ignore-regions.mjs';

--- a/packages/compare-core/tests/compare.test.js
+++ b/packages/compare-core/tests/compare.test.js
@@ -1,0 +1,222 @@
+import pngjs from 'pngjs';
+import { compareBuffers, generateDiffImage, compareWithIgnoreRegions } from '../src/index.mjs';
+
+const { PNG } = pngjs;
+
+/**
+ * Create a synthetic PNG buffer filled with a solid RGBA color.
+ * @param {number} width
+ * @param {number} height
+ * @param {[number, number, number, number]} color
+ * @returns {Buffer}
+ */
+function solidPng(width, height, color) {
+  const png = new PNG({ width, height });
+  for (let i = 0; i < png.data.length; i += 4) {
+    png.data[i] = color[0];
+    png.data[i + 1] = color[1];
+    png.data[i + 2] = color[2];
+    png.data[i + 3] = color[3];
+  }
+  return PNG.sync.write(png);
+}
+
+describe('@snapdrift/compare-core — compareBuffers', () => {
+  test('returns zero mismatch for identical buffers', () => {
+    const buf = solidPng(10, 10, [0, 0, 0, 255]);
+    const result = compareBuffers(buf, buf);
+    expect(result.differentPixels).toBe(0);
+    expect(result.totalPixels).toBe(100);
+    expect(result.mismatchRatio).toBe(0);
+    expect(result.pct).toBe(0);
+    expect(result.pixelsChanged).toBe(0);
+  });
+
+  test('returns full mismatch for completely different buffers', () => {
+    const baseline = solidPng(10, 10, [0, 0, 0, 255]);
+    const current = solidPng(10, 10, [255, 255, 255, 255]);
+    const result = compareBuffers(baseline, current);
+    expect(result.differentPixels).toBe(100);
+    expect(result.totalPixels).toBe(100);
+    expect(result.mismatchRatio).toBe(1);
+  });
+
+  test('returns partial mismatch when some pixels differ', () => {
+    const basePng = new PNG({ width: 2, height: 2 });
+    for (let i = 0; i < basePng.data.length; i += 4) {
+      basePng.data[i] = 0;
+      basePng.data[i + 1] = 0;
+      basePng.data[i + 2] = 0;
+      basePng.data[i + 3] = 255;
+    }
+    const baseBuf = PNG.sync.write(basePng);
+
+    // Create current with 1 pixel different
+    const currentPng = new PNG({ width: 2, height: 2 });
+    for (let i = 0; i < currentPng.data.length; i += 4) {
+      currentPng.data[i] = 0;
+      currentPng.data[i + 1] = 0;
+      currentPng.data[i + 2] = 0;
+      currentPng.data[i + 3] = 255;
+    }
+    // Change pixel at (1,1)
+    currentPng.data[12] = 255;
+    const currentBuf = PNG.sync.write(currentPng);
+
+    const result = compareBuffers(baseBuf, currentBuf);
+    expect(result.differentPixels).toBe(1);
+    expect(result.totalPixels).toBe(4);
+    expect(result.mismatchRatio).toBe(0.25);
+  });
+
+  test('throws on dimension mismatch', () => {
+    const small = solidPng(10, 10, [0, 0, 0, 255]);
+    const large = solidPng(20, 20, [0, 0, 0, 255]);
+    expect(() => compareBuffers(small, large)).toThrow('Dimension mismatch');
+  });
+
+  test('returns width and height', () => {
+    const buf = solidPng(20, 30, [0, 0, 0, 255]);
+    const result = compareBuffers(buf, buf);
+    expect(result.width).toBe(20);
+    expect(result.height).toBe(30);
+  });
+});
+
+describe('@snapdrift/compare-core — generateDiffImage', () => {
+  test('produces a valid PNG buffer', () => {
+    const baseline = solidPng(10, 10, [0, 0, 0, 255]);
+    const current = solidPng(10, 10, [255, 255, 255, 255]);
+    const diffBuf = generateDiffImage(baseline, current);
+    expect(Buffer.isBuffer(diffBuf)).toBe(true);
+    // Should be parseable as PNG
+    const diffPng = PNG.sync.read(diffBuf);
+    expect(diffPng.width).toBe(10);
+    expect(diffPng.height).toBe(10);
+  });
+
+  test('highlights changed pixels with default red color', () => {
+    const baseline = solidPng(2, 2, [0, 0, 0, 255]);
+    // Create current with 1 different pixel
+    const currentPng = new PNG({ width: 2, height: 2 });
+    for (let i = 0; i < currentPng.data.length; i += 4) {
+      currentPng.data[i] = 0;
+      currentPng.data[i + 1] = 0;
+      currentPng.data[i + 2] = 0;
+      currentPng.data[i + 3] = 255;
+    }
+    currentPng.data[0] = 255;
+    const current = PNG.sync.write(currentPng);
+
+    const diffBuf = generateDiffImage(baseline, current);
+    const diffPng = PNG.sync.read(diffBuf);
+
+    // Pixel (0,0) should be red (changed)
+    expect(diffPng.data[0]).toBe(255);  // R
+    expect(diffPng.data[1]).toBe(0);    // G
+    expect(diffPng.data[2]).toBe(0);    // B
+    expect(diffPng.data[3]).toBe(255);   // A
+
+    // Pixel (1,0) should be original (unchanged)
+    expect(diffPng.data[4]).toBe(0);    // R
+    expect(diffPng.data[5]).toBe(0);    // G
+    expect(diffPng.data[6]).toBe(0);    // B
+    expect(diffPng.data[7]).toBe(255);  // A
+  });
+
+  test('uses custom highlight color', () => {
+    const baseline = solidPng(2, 2, [0, 0, 0, 255]);
+    const current = solidPng(2, 2, [255, 255, 255, 255]);
+
+    const diffBuf = generateDiffImage(baseline, current, { highlightColor: [0, 255, 0, 128] });
+    const diffPng = PNG.sync.read(diffBuf);
+
+    // All pixels changed, should be green with alpha 128
+    expect(diffPng.data[0]).toBe(0);    // R
+    expect(diffPng.data[1]).toBe(255);  // G
+    expect(diffPng.data[2]).toBe(0);    // B
+    expect(diffPng.data[3]).toBe(128);  // A
+  });
+
+  test('keeps unchanged pixels at original color', () => {
+    const baseline = solidPng(10, 10, [0, 0, 0, 255]);
+    const diffBuf = generateDiffImage(baseline, baseline);
+    const diffPng = PNG.sync.read(diffBuf);
+
+    // First pixel unchanged = original color
+    expect(diffPng.data[0]).toBe(0);
+    expect(diffPng.data[1]).toBe(0);
+    expect(diffPng.data[2]).toBe(0);
+    expect(diffPng.data[3]).toBe(255);
+  });
+
+  test('throws on dimension mismatch', () => {
+    const small = solidPng(10, 10, [0, 0, 0, 255]);
+    const large = solidPng(20, 20, [0, 0, 0, 255]);
+    expect(() => generateDiffImage(small, large)).toThrow('Dimension mismatch');
+  });
+});
+
+describe('@snapdrift/compare-core — compareWithIgnoreRegions', () => {
+  test('excludes ignore region pixels from totals', () => {
+    // 4x4 image, baseline all black, current all white
+    // Ignore top-left 2x2 region = 4 pixels excluded
+    const baseline = solidPng(4, 4, [0, 0, 0, 255]);
+    const current = solidPng(4, 4, [255, 255, 255, 255]);
+
+    const result = compareWithIgnoreRegions(baseline, current, [
+      { x: 0, y: 0, width: 2, height: 2 }
+    ]);
+    expect(result.totalPixels).toBe(12); // 16 - 4
+    expect(result.differentPixels).toBe(12);
+    expect(result.mismatchRatio).toBe(1);
+  });
+
+  test('no ignore regions behaves like compareBuffers', () => {
+    const baseline = solidPng(10, 10, [0, 0, 0, 255]);
+    const current = solidPng(10, 10, [255, 255, 255, 255]);
+    const withIgnore = compareWithIgnoreRegions(baseline, current, []);
+    const without = compareBuffers(baseline, current);
+    expect(withIgnore.differentPixels).toBe(without.differentPixels);
+    expect(withIgnore.totalPixels).toBe(without.totalPixels);
+  });
+
+  test('clamps ignore region to image bounds', () => {
+    const baseline = solidPng(4, 4, [0, 0, 0, 255]);
+    const current = solidPng(4, 4, [255, 255, 255, 255]);
+
+    // Region extends beyond image — should be clamped
+    const result = compareWithIgnoreRegions(baseline, current, [
+      { x: 2, y: 2, width: 10, height: 10 }
+    ]);
+    // Only 4 pixels in the clamped 2x2 region at (2,2) are ignored
+    expect(result.totalPixels).toBe(12);
+    expect(result.differentPixels).toBe(12);
+  });
+
+  test('overlapping ignore regions do not double-count', () => {
+    const baseline = solidPng(4, 4, [0, 0, 0, 255]);
+    const current = solidPng(4, 4, [255, 255, 255, 255]);
+
+    // Two overlapping regions covering the same 2x2 area
+    const result = compareWithIgnoreRegions(baseline, current, [
+      { x: 0, y: 0, width: 2, height: 2 },
+      { x: 0, y: 0, width: 2, height: 2 }
+    ]);
+    // Overlapping regions don't double-exclude — still 4 pixels ignored
+    expect(result.totalPixels).toBe(12);
+  });
+
+  test('throws on dimension mismatch', () => {
+    const small = solidPng(10, 10, [0, 0, 0, 255]);
+    const large = solidPng(20, 20, [0, 0, 0, 255]);
+    expect(() => compareWithIgnoreRegions(small, large, [])).toThrow('Dimension mismatch');
+  });
+
+  test('returns width and height', () => {
+    const buf = solidPng(20, 30, [0, 0, 0, 255]);
+    const result = compareWithIgnoreRegions(buf, buf, []);
+    expect(result.width).toBe(20);
+    expect(result.height).toBe(30);
+  });
+});

--- a/packages/compare-core/tests/compare.test.js
+++ b/packages/compare-core/tests/compare.test.js
@@ -81,6 +81,25 @@ describe('@snapdrift/compare-core — compareBuffers', () => {
     expect(result.width).toBe(20);
     expect(result.height).toBe(30);
   });
+
+  test('returns full-precision mismatchRatio (no rounding)', () => {
+    // 1 pixel different out of 7 = 1/7 = 0.142857142857...
+    const basePng = new PNG({ width: 7, height: 1 });
+    for (let i = 0; i < basePng.data.length; i += 4) {
+      basePng.data[i] = 0; basePng.data[i + 1] = 0; basePng.data[i + 2] = 0; basePng.data[i + 3] = 255;
+    }
+    const currentPng = new PNG({ width: 7, height: 1 });
+    for (let i = 0; i < currentPng.data.length; i += 4) {
+      currentPng.data[i] = 0; currentPng.data[i + 1] = 0; currentPng.data[i + 2] = 0; currentPng.data[i + 3] = 255;
+    }
+    // Change pixel at (3,0)
+    currentPng.data[12] = 255;
+    const baseBuf = PNG.sync.write(basePng);
+    const currentBuf = PNG.sync.write(currentPng);
+    const result = compareBuffers(baseBuf, currentBuf);
+    expect(result.mismatchRatio).toBeCloseTo(1 / 7, 10);
+    expect(result.pct).toBe(result.mismatchRatio);
+  });
 });
 
 describe('@snapdrift/compare-core — generateDiffImage', () => {

--- a/packages/compare-core/types/index.d.ts
+++ b/packages/compare-core/types/index.d.ts
@@ -1,0 +1,32 @@
+/**
+ * Comparison result types for @snapdrift/compare-core.
+ */
+
+export interface IgnoreRegion {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface DiffImageOptions {
+  /** RGBA color for changed pixels. Default: [255, 0, 0, 255] (red). */
+  highlightColor?: [number, number, number, number];
+}
+
+export interface CompareResult {
+  width: number;
+  height: number;
+  differentPixels: number;
+  totalPixels: number;
+  /** Ratio of different to total pixels (0–1). Alias: `pct`. */
+  mismatchRatio: number;
+  /** Alias for `mismatchRatio`. ADR-convention name. */
+  pct: number;
+  /** Alias for `differentPixels`. ADR-convention name. */
+  pixelsChanged: number;
+  /** Visual diff image buffer, only present when generated via diff-image mode. */
+  diffImageBuffer?: Buffer;
+}
+
+export type CompareBuffersResult = CompareResult;

--- a/packages/compare-core/types/index.d.ts
+++ b/packages/compare-core/types/index.d.ts
@@ -12,6 +12,8 @@ export interface IgnoreRegion {
 export interface DiffImageOptions {
   /** RGBA color for changed pixels. Default: [255, 0, 0, 255] (red). */
   highlightColor?: [number, number, number, number];
+  /** Not yet implemented (Phase 1b). Pixels in ignore regions will be overlaid with a neutral mask. */
+  ignoreRegions?: IgnoreRegion[];
 }
 
 export interface CompareResult {

--- a/packages/manifest/package.json
+++ b/packages/manifest/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@snapdrift/manifest",
+  "version": "1.0.0",
+  "description": "SnapDrift manifest schema, validation, and indexing — pure, zero I/O",
+  "type": "module",
+  "main": "src/index.mjs",
+  "exports": {
+    ".": "./src/index.mjs"
+  },
+  "types": "types/index.d.ts",
+  "files": [
+    "src/",
+    "types/"
+  ],
+  "engines": {
+    "node": ">=22"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ranacseruet/snapdrift.git",
+    "directory": "packages/manifest"
+  }
+}

--- a/packages/manifest/src/index.mjs
+++ b/packages/manifest/src/index.mjs
@@ -1,0 +1,4 @@
+// @ts-check
+
+export { validateManifest, indexManifestEntries, indexRouteResults, CURRENT_SCHEMA_VERSION } from './schema.mjs';
+export { viewportKey, viewportHash } from './viewport.mjs';

--- a/packages/manifest/src/index.mjs
+++ b/packages/manifest/src/index.mjs
@@ -1,4 +1,4 @@
 // @ts-check
 
 export { validateManifest, indexManifestEntries, indexRouteResults, CURRENT_SCHEMA_VERSION } from './schema.mjs';
-export { viewportKey, viewportHash } from './viewport.mjs';
+export { viewportKey, viewportHash, VIEWPORT_PRESETS } from './viewport.mjs';

--- a/packages/manifest/src/schema.mjs
+++ b/packages/manifest/src/schema.mjs
@@ -7,8 +7,8 @@
 const CURRENT_SCHEMA_VERSION = 1;
 
 /**
- * Validate a screenshot manifest object.
- * Accepts manifests without `schemaVersion` (defaults to 1).
+ * Validate and normalise a screenshot manifest object.
+ * If `schemaVersion` is absent, it is set to CURRENT_SCHEMA_VERSION (1).
  *
  * @param {unknown} value
  * @returns {ScreenshotManifest}
@@ -22,6 +22,10 @@ export function validateManifest(value) {
 
   if (candidate.schemaVersion !== undefined && typeof candidate.schemaVersion !== 'number') {
     throw new Error('manifest.schemaVersion must be a number when present.');
+  }
+
+  if (candidate.schemaVersion === undefined) {
+    candidate.schemaVersion = CURRENT_SCHEMA_VERSION;
   }
 
   if (typeof candidate.generatedAt !== 'string' || !candidate.generatedAt) {

--- a/packages/manifest/src/schema.mjs
+++ b/packages/manifest/src/schema.mjs
@@ -1,0 +1,98 @@
+// @ts-check
+
+/** @typedef {import('../types/index.d.ts').VisualScreenshotManifest} ScreenshotManifest */
+/** @typedef {import('../types/index.d.ts').VisualScreenshotManifestEntry} ScreenshotManifestEntry */
+/** @typedef {import('../types/index.d.ts').VisualBaselineResults} BaselineResults */
+
+const CURRENT_SCHEMA_VERSION = 1;
+
+/**
+ * Validate a screenshot manifest object.
+ * Accepts manifests without `schemaVersion` (defaults to 1).
+ *
+ * @param {unknown} value
+ * @returns {ScreenshotManifest}
+ */
+export function validateManifest(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('Manifest must be a non-null object.');
+  }
+
+  const candidate = /** @type {Record<string, unknown>} */ (value);
+
+  if (candidate.schemaVersion !== undefined && typeof candidate.schemaVersion !== 'number') {
+    throw new Error('manifest.schemaVersion must be a number when present.');
+  }
+
+  if (typeof candidate.generatedAt !== 'string' || !candidate.generatedAt) {
+    throw new Error('manifest.generatedAt must be a non-empty ISO date string.');
+  }
+
+  if (typeof candidate.baseUrl !== 'string') {
+    throw new Error('manifest.baseUrl must be a string.');
+  }
+
+  if (!Array.isArray(candidate.screenshots)) {
+    throw new Error('manifest.screenshots must be an array.');
+  }
+
+  const ids = new Set();
+  for (const [index, entry] of candidate.screenshots.entries()) {
+    if (!entry || typeof entry !== 'object') {
+      throw new Error(`manifest.screenshots[${index}] must be an object.`);
+    }
+    const e = /** @type {Record<string, unknown>} */ (entry);
+    if (typeof e.id !== 'string' || !e.id) {
+      throw new Error(`manifest.screenshots[${index}].id must be a non-empty string.`);
+    }
+    if (ids.has(e.id)) {
+      throw new Error(`Duplicate screenshot id "${e.id}" in manifest.`);
+    }
+    ids.add(e.id);
+    if (typeof e.path !== 'string') {
+      throw new Error(`manifest.screenshots[${index}].path must be a string.`);
+    }
+    if (typeof e.width !== 'number' || !Number.isFinite(e.width) || e.width <= 0) {
+      throw new Error(`manifest.screenshots[${index}].width must be a positive number.`);
+    }
+    if (typeof e.height !== 'number' || !Number.isFinite(e.height) || e.height <= 0) {
+      throw new Error(`manifest.screenshots[${index}].height must be a positive number.`);
+    }
+  }
+
+  return /** @type {ScreenshotManifest} */ (value);
+}
+
+/**
+ * Index manifest entries by id, filtered to selected route ids.
+ *
+ * @param {ScreenshotManifest} manifest
+ * @param {string[]} selectedRouteIds
+ * @returns {Map<string, ScreenshotManifestEntry>}
+ */
+export function indexManifestEntries(manifest, selectedRouteIds) {
+  const selected = new Set(selectedRouteIds);
+  const entries = new Map();
+  for (const screenshot of manifest.screenshots || []) {
+    if (!selected.has(screenshot.id)) {
+      continue;
+    }
+    if (entries.has(screenshot.id)) {
+      throw new Error(`Duplicate screenshot id ${screenshot.id} detected in the SnapDrift screenshot manifest.`);
+    }
+    entries.set(screenshot.id, screenshot);
+  }
+  return entries;
+}
+
+/**
+ * Index route results by id.
+ *
+ * @param {BaselineResults} results
+ * @returns {Map<string, BaselineResults['routes'][number]>}
+ */
+export function indexRouteResults(results) {
+  return new Map((results.routes || []).map((route) => [route.id, route]));
+}
+
+export { CURRENT_SCHEMA_VERSION };

--- a/packages/manifest/src/schema.mjs
+++ b/packages/manifest/src/schema.mjs
@@ -52,6 +52,19 @@ export function validateManifest(value) {
     if (typeof e.path !== 'string') {
       throw new Error(`manifest.screenshots[${index}].path must be a string.`);
     }
+    if (typeof e.imagePath !== 'string' || !e.imagePath) {
+      throw new Error(`manifest.screenshots[${index}].imagePath must be a non-empty string.`);
+    }
+    if (e.viewport !== undefined && e.viewport !== null) {
+      const vp = e.viewport;
+      const isPreset = typeof vp === 'string';
+      const isCustom = typeof vp === 'object' && !Array.isArray(vp) && typeof /** @type {{width: number, height: number}} */ (vp).width === 'number' && typeof /** @type {{width: number, height: number}} */ (vp).height === 'number';
+      if (!isPreset && !isCustom) {
+        throw new Error(`manifest.screenshots[${index}].viewport must be a preset string or an object with width and height.`);
+      }
+    } else {
+      throw new Error(`manifest.screenshots[${index}].viewport is required.`);
+    }
     if (typeof e.width !== 'number' || !Number.isFinite(e.width) || e.width <= 0) {
       throw new Error(`manifest.screenshots[${index}].width must be a positive number.`);
     }

--- a/packages/manifest/src/viewport.mjs
+++ b/packages/manifest/src/viewport.mjs
@@ -4,9 +4,19 @@
 /** @typedef {import('../types/index.d.ts').VisualViewport} VisualViewport */
 
 /**
+ * Single source of truth for viewport presets.
+ * Dimensions and flags must match exactly for a preset match —
+ * partial matches (right dimensions, wrong flags) fall through to `custom:WxH`.
+ * @type {Record<string, ViewportDescriptor & { width: number, height: number }>}
+ */
+export const VIEWPORT_PRESETS = {
+  desktop: { width: 1440, height: 900, deviceScaleFactor: 1, isMobile: false, hasTouch: false },
+  mobile: { width: 390, height: 844, deviceScaleFactor: 3, isMobile: true, hasTouch: true }
+};
+
+/**
  * Produce a stable string key for a viewport value.
- * Matches existing snapdrift behavior: preset names pass through,
- * custom dimensions get `custom:{w}x{h}`.
+ * Preset names pass through; custom dimensions get `custom:{w}x{h}`.
  *
  * @param {VisualViewport} viewport
  * @returns {string}
@@ -17,27 +27,21 @@ export function viewportKey(viewport) {
 
 /**
  * Produce a stable hash for a normalised viewport descriptor.
- * Uses the compact format `viewportHash` format from the ADR:
- * preset presets map to their name, custom viewports to `custom:WxH`.
+ * All preset fields (dimensions + flags) must match exactly —
+ * a descriptor with matching dimensions but missing or conflicting
+ * flags falls through to `custom:WxH` rather than silently matching
+ * a preset with different device characteristics.
  *
  * @param {ViewportDescriptor} descriptor
  * @returns {string}
  */
 export function viewportHash(descriptor) {
-  // Check known presets first
-  if (
-    descriptor.width === 1440 && descriptor.height === 900 &&
-    (descriptor.deviceScaleFactor === undefined || descriptor.deviceScaleFactor === 1) &&
-    (descriptor.isMobile === undefined || descriptor.isMobile === false)
-  ) {
-    return 'desktop';
-  }
-  if (
-    descriptor.width === 390 && descriptor.height === 844 &&
-    (descriptor.deviceScaleFactor === undefined || descriptor.deviceScaleFactor === 3) &&
-    (descriptor.isMobile === undefined || descriptor.isMobile === true)
-  ) {
-    return 'mobile';
+  for (const [name, preset] of Object.entries(VIEWPORT_PRESETS)) {
+    if (descriptor.width !== preset.width || descriptor.height !== preset.height) continue;
+    if (descriptor.deviceScaleFactor !== undefined && descriptor.deviceScaleFactor !== preset.deviceScaleFactor) continue;
+    if (descriptor.isMobile !== undefined && descriptor.isMobile !== preset.isMobile) continue;
+    if (descriptor.hasTouch !== undefined && descriptor.hasTouch !== preset.hasTouch) continue;
+    return name;
   }
   return `custom:${descriptor.width}x${descriptor.height}`;
 }

--- a/packages/manifest/src/viewport.mjs
+++ b/packages/manifest/src/viewport.mjs
@@ -1,0 +1,43 @@
+// @ts-check
+
+/** @typedef {import('../types/index.d.ts').ViewportDescriptor} ViewportDescriptor */
+/** @typedef {import('../types/index.d.ts').VisualViewport} VisualViewport */
+
+/**
+ * Produce a stable string key for a viewport value.
+ * Matches existing snapdrift behavior: preset names pass through,
+ * custom dimensions get `custom:{w}x{h}`.
+ *
+ * @param {VisualViewport} viewport
+ * @returns {string}
+ */
+export function viewportKey(viewport) {
+  return typeof viewport === 'string' ? viewport : `custom:${viewport.width}x${viewport.height}`;
+}
+
+/**
+ * Produce a stable hash for a normalised viewport descriptor.
+ * Uses the compact format `viewportHash` format from the ADR:
+ * preset presets map to their name, custom viewports to `custom:WxH`.
+ *
+ * @param {ViewportDescriptor} descriptor
+ * @returns {string}
+ */
+export function viewportHash(descriptor) {
+  // Check known presets first
+  if (
+    descriptor.width === 1440 && descriptor.height === 900 &&
+    (descriptor.deviceScaleFactor === undefined || descriptor.deviceScaleFactor === 1) &&
+    (descriptor.isMobile === undefined || descriptor.isMobile === false)
+  ) {
+    return 'desktop';
+  }
+  if (
+    descriptor.width === 390 && descriptor.height === 844 &&
+    (descriptor.deviceScaleFactor === undefined || descriptor.deviceScaleFactor === 3) &&
+    (descriptor.isMobile === undefined || descriptor.isMobile === true)
+  ) {
+    return 'mobile';
+  }
+  return `custom:${descriptor.width}x${descriptor.height}`;
+}

--- a/packages/manifest/tests/schema.test.js
+++ b/packages/manifest/tests/schema.test.js
@@ -1,0 +1,129 @@
+import { validateManifest, indexManifestEntries, indexRouteResults, CURRENT_SCHEMA_VERSION } from '../src/index.mjs';
+
+const VALID_MANIFEST = {
+  generatedAt: '2024-01-01T00:00:00.000Z',
+  baseUrl: 'http://localhost:8080',
+  screenshots: [
+    { id: 'home-desktop', path: '/', viewport: 'desktop', imagePath: 'screenshots/home-desktop.png', width: 1440, height: 900 },
+    { id: 'home-mobile', path: '/', viewport: 'mobile', imagePath: 'screenshots/home-mobile.png', width: 390, height: 844 }
+  ]
+};
+
+describe('@snapdrift/manifest — validateManifest', () => {
+  test('accepts a valid manifest', () => {
+    const result = validateManifest(VALID_MANIFEST);
+    expect(result.screenshots).toHaveLength(2);
+  });
+
+  test('accepts manifest with schemaVersion', () => {
+    const withVersion = { ...VALID_MANIFEST, schemaVersion: 1 };
+    const result = validateManifest(withVersion);
+    expect(result.schemaVersion).toBe(1);
+  });
+
+  test('accepts manifest without schemaVersion (defaults to 1)', () => {
+    const result = validateManifest(VALID_MANIFEST);
+    expect(result.schemaVersion).toBeUndefined();
+  });
+
+  test('rejects non-object', () => {
+    expect(() => validateManifest(null)).toThrow('non-null object');
+    expect(() => validateManifest('string')).toThrow('non-null object');
+    expect(() => validateManifest([])).toThrow('non-null object');
+  });
+
+  test('rejects invalid schemaVersion', () => {
+    expect(() => validateManifest({ ...VALID_MANIFEST, schemaVersion: 'bad' })).toThrow('number');
+  });
+
+  test('rejects missing generatedAt', () => {
+    const { generatedAt, ...without } = VALID_MANIFEST;
+    expect(() => validateManifest(without)).toThrow('generatedAt');
+  });
+
+  test('rejects empty generatedAt', () => {
+    expect(() => validateManifest({ ...VALID_MANIFEST, generatedAt: '' })).toThrow('generatedAt');
+  });
+
+  test('rejects missing screenshots array', () => {
+    const { screenshots, ...without } = VALID_MANIFEST;
+    expect(() => validateManifest(without)).toThrow('screenshots');
+  });
+
+  test('rejects duplicate screenshot ids', () => {
+    const dup = {
+      ...VALID_MANIFEST,
+      screenshots: [
+        ...VALID_MANIFEST.screenshots,
+        { id: 'home-desktop', path: '/dup', viewport: 'desktop', imagePath: 'screenshots/dup.png', width: 1440, height: 900 }
+      ]
+    };
+    expect(() => validateManifest(dup)).toThrow('Duplicate');
+  });
+
+  test('rejects screenshot with missing id', () => {
+    const bad = { ...VALID_MANIFEST, screenshots: [{ path: '/', width: 100, height: 100 }] };
+    expect(() => validateManifest(bad)).toThrow('id');
+  });
+
+  test('rejects screenshot with non-positive width', () => {
+    const bad = { ...VALID_MANIFEST, screenshots: [{ id: 'a', path: '/', width: 0, height: 100, viewport: 'desktop', imagePath: 'a.png' }] };
+    expect(() => validateManifest(bad)).toThrow('width');
+  });
+});
+
+describe('@snapdrift/manifest — indexManifestEntries', () => {
+  test('indexes entries by id filtered by selected routes', () => {
+    const indexed = indexManifestEntries(VALID_MANIFEST, ['home-desktop']);
+    expect(indexed.size).toBe(1);
+    expect(indexed.get('home-desktop').id).toBe('home-desktop');
+  });
+
+  test('returns all entries when selected is empty', () => {
+    const indexed = indexManifestEntries(VALID_MANIFEST, []);
+    expect(indexed.size).toBe(0);
+  });
+
+  test('returns all entries when selected matches all ids', () => {
+    const indexed = indexManifestEntries(VALID_MANIFEST, ['home-desktop', 'home-mobile']);
+    expect(indexed.size).toBe(2);
+  });
+
+  test('throws on duplicate ids', () => {
+    const dup = {
+      ...VALID_MANIFEST,
+      screenshots: [
+        { id: 'a', path: '/', viewport: 'desktop', imagePath: '1.png', width: 100, height: 100 },
+        { id: 'a', path: '/', viewport: 'mobile', imagePath: '2.png', width: 100, height: 100 }
+      ]
+    };
+    expect(() => indexManifestEntries(dup, ['a'])).toThrow('Duplicate');
+  });
+});
+
+describe('@snapdrift/manifest — indexRouteResults', () => {
+  test('indexes routes by id', () => {
+    const results = {
+      startedAt: '2024-01-01T00:00:00Z',
+      routes: [
+        { id: 'home', path: '/', viewport: 'desktop', status: 'passed', durationMs: 100 },
+        { id: 'about', path: '/about', viewport: 'desktop', status: 'failed', durationMs: 50, error: 'timeout' }
+      ]
+    };
+    const indexed = indexRouteResults(results);
+    expect(indexed.size).toBe(2);
+    expect(indexed.get('home').status).toBe('passed');
+    expect(indexed.get('about').status).toBe('failed');
+  });
+
+  test('handles empty routes', () => {
+    const indexed = indexRouteResults({ startedAt: '', routes: [] });
+    expect(indexed.size).toBe(0);
+  });
+});
+
+describe('@snapdrift/manifest — CURRENT_SCHEMA_VERSION', () => {
+  test('is 1', () => {
+    expect(CURRENT_SCHEMA_VERSION).toBe(1);
+  });
+});

--- a/packages/manifest/tests/schema.test.js
+++ b/packages/manifest/tests/schema.test.js
@@ -70,6 +70,34 @@ describe('@snapdrift/manifest — validateManifest', () => {
     const bad = { ...VALID_MANIFEST, screenshots: [{ id: 'a', path: '/', width: 0, height: 100, viewport: 'desktop', imagePath: 'a.png' }] };
     expect(() => validateManifest(bad)).toThrow('width');
   });
+
+  test('rejects screenshot with missing imagePath', () => {
+    const { imagePath, ...entryWithout } = VALID_MANIFEST.screenshots[0];
+    const bad = { ...VALID_MANIFEST, screenshots: [entryWithout] };
+    expect(() => validateManifest(bad)).toThrow('imagePath');
+  });
+
+  test('rejects screenshot with empty imagePath', () => {
+    const bad = { ...VALID_MANIFEST, screenshots: [{ ...VALID_MANIFEST.screenshots[0], imagePath: '' }] };
+    expect(() => validateManifest(bad)).toThrow('imagePath');
+  });
+
+  test('rejects screenshot with missing viewport', () => {
+    const { viewport, ...entryWithout } = VALID_MANIFEST.screenshots[0];
+    const bad = { ...VALID_MANIFEST, screenshots: [entryWithout] };
+    expect(() => validateManifest(bad)).toThrow('viewport');
+  });
+
+  test('rejects screenshot with invalid viewport type', () => {
+    const bad = { ...VALID_MANIFEST, screenshots: [{ ...VALID_MANIFEST.screenshots[0], viewport: 123 }] };
+    expect(() => validateManifest(bad)).toThrow('viewport');
+  });
+
+  test('accepts screenshot with custom viewport object', () => {
+    const custom = { ...VALID_MANIFEST, screenshots: [{ ...VALID_MANIFEST.screenshots[0], viewport: { width: 1280, height: 720 } }] };
+    const result = validateManifest(custom);
+    expect(result.screenshots[0].viewport).toEqual({ width: 1280, height: 720 });
+  });
 });
 
 describe('@snapdrift/manifest — indexManifestEntries', () => {

--- a/packages/manifest/tests/schema.test.js
+++ b/packages/manifest/tests/schema.test.js
@@ -21,9 +21,9 @@ describe('@snapdrift/manifest — validateManifest', () => {
     expect(result.schemaVersion).toBe(1);
   });
 
-  test('accepts manifest without schemaVersion (defaults to 1)', () => {
+  test('defaults schemaVersion to 1 when absent', () => {
     const result = validateManifest(VALID_MANIFEST);
-    expect(result.schemaVersion).toBeUndefined();
+    expect(result.schemaVersion).toBe(1);
   });
 
   test('rejects non-object', () => {

--- a/packages/manifest/tests/viewport.test.js
+++ b/packages/manifest/tests/viewport.test.js
@@ -1,0 +1,39 @@
+import { viewportKey, viewportHash } from '../src/index.mjs';
+
+describe('@snapdrift/manifest — viewportKey', () => {
+  test('passes preset strings through unchanged', () => {
+    expect(viewportKey('desktop')).toBe('desktop');
+    expect(viewportKey('mobile')).toBe('mobile');
+  });
+
+  test('formats custom viewports as custom:WxH', () => {
+    expect(viewportKey({ width: 1280, height: 720 })).toBe('custom:1280x720');
+    expect(viewportKey({ width: 768, height: 1024 })).toBe('custom:768x1024');
+  });
+});
+
+describe('@snapdrift/manifest — viewportHash', () => {
+  test('returns "desktop" for the desktop preset descriptor', () => {
+    expect(viewportHash({ width: 1440, height: 900, deviceScaleFactor: 1, isMobile: false, hasTouch: false })).toBe('desktop');
+  });
+
+  test('returns "desktop" with defaults', () => {
+    expect(viewportHash({ width: 1440, height: 900 })).toBe('desktop');
+  });
+
+  test('returns "mobile" for the mobile preset descriptor', () => {
+    expect(viewportHash({ width: 390, height: 844, deviceScaleFactor: 3, isMobile: true, hasTouch: true })).toBe('mobile');
+  });
+
+  test('returns "mobile" with defaults', () => {
+    expect(viewportHash({ width: 390, height: 844, isMobile: true })).toBe('mobile');
+  });
+
+  test('returns custom format for non-preset dimensions', () => {
+    expect(viewportHash({ width: 1280, height: 720 })).toBe('custom:1280x720');
+  });
+
+  test('returns custom for desktop dimensions with mobile flag', () => {
+    expect(viewportHash({ width: 1440, height: 900, isMobile: true })).toBe('custom:1440x900');
+  });
+});

--- a/packages/manifest/tests/viewport.test.js
+++ b/packages/manifest/tests/viewport.test.js
@@ -1,4 +1,4 @@
-import { viewportKey, viewportHash } from '../src/index.mjs';
+import { viewportKey, viewportHash, VIEWPORT_PRESETS } from '../src/index.mjs';
 
 describe('@snapdrift/manifest — viewportKey', () => {
   test('passes preset strings through unchanged', () => {
@@ -13,27 +13,58 @@ describe('@snapdrift/manifest — viewportKey', () => {
 });
 
 describe('@snapdrift/manifest — viewportHash', () => {
-  test('returns "desktop" for the desktop preset descriptor', () => {
+  test('returns "desktop" for a fully-matching desktop preset descriptor', () => {
     expect(viewportHash({ width: 1440, height: 900, deviceScaleFactor: 1, isMobile: false, hasTouch: false })).toBe('desktop');
   });
 
-  test('returns "desktop" with defaults', () => {
+  test('returns "desktop" when optional flags are omitted (they match the preset default)', () => {
     expect(viewportHash({ width: 1440, height: 900 })).toBe('desktop');
   });
 
-  test('returns "mobile" for the mobile preset descriptor', () => {
+  test('returns "mobile" for a fully-matching mobile preset descriptor', () => {
     expect(viewportHash({ width: 390, height: 844, deviceScaleFactor: 3, isMobile: true, hasTouch: true })).toBe('mobile');
   });
 
-  test('returns "mobile" with defaults', () => {
-    expect(viewportHash({ width: 390, height: 844, isMobile: true })).toBe('mobile');
+  test('returns "mobile" when optional flags are omitted', () => {
+    expect(viewportHash({ width: 390, height: 844 })).toBe('mobile');
   });
 
-  test('returns custom format for non-preset dimensions', () => {
+  test('returns custom for desktop dimensions with conflicting isMobile flag', () => {
+    expect(viewportHash({ width: 1440, height: 900, isMobile: true })).toBe('custom:1440x900');
+  });
+
+  test('returns custom for mobile dimensions with conflicting isMobile flag', () => {
+    expect(viewportHash({ width: 390, height: 844, isMobile: false })).toBe('custom:390x844');
+  });
+
+  test('returns custom for non-preset dimensions', () => {
     expect(viewportHash({ width: 1280, height: 720 })).toBe('custom:1280x720');
   });
 
-  test('returns custom for desktop dimensions with mobile flag', () => {
-    expect(viewportHash({ width: 1440, height: 900, isMobile: true })).toBe('custom:1440x900');
+  test('returns custom when deviceScaleFactor conflicts with preset', () => {
+    expect(viewportHash({ width: 1440, height: 900, deviceScaleFactor: 3 })).toBe('custom:1440x900');
+  });
+});
+
+describe('@snapdrift/manifest — VIEWPORT_PRESETS', () => {
+  test('has desktop and mobile entries', () => {
+    expect(VIEWPORT_PRESETS.desktop).toBeDefined();
+    expect(VIEWPORT_PRESETS.mobile).toBeDefined();
+  });
+
+  test('desktop preset has expected dimensions and flags', () => {
+    expect(VIEWPORT_PRESETS.desktop.width).toBe(1440);
+    expect(VIEWPORT_PRESETS.desktop.height).toBe(900);
+    expect(VIEWPORT_PRESETS.desktop.deviceScaleFactor).toBe(1);
+    expect(VIEWPORT_PRESETS.desktop.isMobile).toBe(false);
+    expect(VIEWPORT_PRESETS.desktop.hasTouch).toBe(false);
+  });
+
+  test('mobile preset has expected dimensions and flags', () => {
+    expect(VIEWPORT_PRESETS.mobile.width).toBe(390);
+    expect(VIEWPORT_PRESETS.mobile.height).toBe(844);
+    expect(VIEWPORT_PRESETS.mobile.deviceScaleFactor).toBe(3);
+    expect(VIEWPORT_PRESETS.mobile.isMobile).toBe(true);
+    expect(VIEWPORT_PRESETS.mobile.hasTouch).toBe(true);
   });
 });

--- a/packages/manifest/types/index.d.ts
+++ b/packages/manifest/types/index.d.ts
@@ -1,0 +1,177 @@
+/**
+ * SnapDrift manifest and configuration types.
+ *
+ * These types define the contract between capture, comparison, and report
+ * components. They are shared across providers (filesystem, S3, etc.).
+ */
+
+export type VisualViewportPreset = 'desktop' | 'mobile';
+
+export interface VisualCustomViewport {
+  width: number;
+  height: number;
+}
+
+export type VisualViewport = VisualViewportPreset | VisualCustomViewport;
+
+/**
+ * Normalised viewport descriptor used for cross-provider hashing and comparison.
+ * Both preset names and custom dimensions resolve to this shape.
+ */
+export interface ViewportDescriptor {
+  width: number;
+  height: number;
+  deviceScaleFactor?: number;
+  isMobile?: boolean;
+  hasTouch?: boolean;
+}
+
+export interface VisualRegressionSelectionConfig {
+  sharedPrefixes?: string[];
+  sharedExact?: string[];
+}
+
+export interface VisualRegressionRouteConfig {
+  id: string;
+  path: string;
+  viewport: VisualViewport;
+  changePaths?: string[];
+  navigationTimeout?: number;
+}
+
+export interface VisualRegressionConfig {
+  baselineArtifactName: string;
+  workingDirectory: string;
+  baseUrl: string;
+  resultsFile: string;
+  manifestFile: string;
+  screenshotsRoot: string;
+  routes: VisualRegressionRouteConfig[];
+  diff: {
+    threshold: number;
+    mode: 'report-only' | 'fail-on-changes' | 'fail-on-incomplete' | 'strict';
+  };
+  selection?: VisualRegressionSelectionConfig;
+}
+
+export interface VisualBaselineRouteResult {
+  id: string;
+  path: string;
+  viewport: VisualViewport;
+  status: 'passed' | 'failed' | 'skipped';
+  durationMs: number;
+  imagePath?: string;
+  width?: number;
+  height?: number;
+  error?: string;
+}
+
+export interface VisualScreenshotManifestEntry {
+  id: string;
+  path: string;
+  viewport: VisualViewport;
+  imagePath: string;
+  width: number;
+  height: number;
+}
+
+export interface VisualScreenshotManifest {
+  /** Schema version. Omitted in v0 manifests; defaults to 1 when absent. */
+  schemaVersion?: number;
+  generatedAt: string;
+  baseUrl: string;
+  screenshots: VisualScreenshotManifestEntry[];
+}
+
+export interface VisualBaselineResults {
+  startedAt: string;
+  finishedAt?: string;
+  baseUrl: string;
+  suite: string;
+  configPath?: string;
+  manifestPath?: string;
+  screenshotsRoot?: string;
+  routes: VisualBaselineRouteResult[];
+  passed?: boolean;
+}
+
+/**
+ * Capture profile metadata for engine-version validation across providers.
+ * Snap stores this on baselines and runs; snapdrift writes it into manifests.
+ */
+export interface CaptureProfile {
+  engineVersion: string;
+  browser?: string;
+  browserRevision?: string;
+  fontsHash?: string;
+  timezone?: string;
+  locale?: string;
+}
+
+export interface VisualDiffMissingItem {
+  id: string;
+  reason: string;
+  path?: string;
+  viewport?: VisualViewport;
+  location: 'baseline' | 'current';
+}
+
+export interface VisualDiffErrorItem {
+  id: string;
+  path?: string;
+  viewport?: VisualViewport;
+  status: 'error';
+  message: string;
+}
+
+export interface VisualDiffDimensionItem {
+  id: string;
+  path?: string;
+  viewport?: VisualViewport;
+  baselineWidth: number;
+  baselineHeight: number;
+  currentWidth: number;
+  currentHeight: number;
+  status: 'dimension-changed';
+}
+
+export interface VisualDiffChangedItem {
+  id: string;
+  path: string;
+  viewport: VisualViewport;
+  baselineImagePath: string;
+  currentImagePath: string;
+  width: number;
+  height: number;
+  differentPixels: number;
+  totalPixels: number;
+  mismatchRatio: number;
+  status: 'changed';
+}
+
+export interface VisualDiffSummary {
+  startedAt: string;
+  finishedAt?: string;
+  completed?: boolean;
+  status?: 'clean' | 'changes-detected' | 'incomplete' | 'skipped';
+  selectedRoutes?: string[];
+  baselineArtifactName?: string;
+  baselineSourceSha?: string;
+  baselineAvailable?: boolean;
+  baselineManifestPath: string;
+  currentManifestPath: string;
+  diffMode: 'report-only' | 'fail-on-changes' | 'fail-on-incomplete' | 'strict';
+  threshold: number;
+  baselineResultsPath: string;
+  currentResultsPath: string;
+  totalScreenshots: number;
+  matchedScreenshots: number;
+  changedScreenshots: number;
+  missingInBaseline: number;
+  missingInCurrent: number;
+  changed: VisualDiffChangedItem[];
+  missing: VisualDiffMissingItem[];
+  errors: VisualDiffErrorItem[];
+  dimensionChanges: VisualDiffDimensionItem[];
+  message?: string;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,8 @@
   },
   "include": [
     "lib/**/*.mjs",
-    "scripts/**/*.mjs"
+    "scripts/**/*.mjs",
+    "packages/*/src/**/*.mjs",
+    "packages/*/types/*.d.ts"
   ]
 }


### PR DESCRIPTION
## Summary

Phase 1a of the layered package extraction (issue #58). Snap needs byte-identical comparison math from snapdrift, but its I/O is S3+DB vs filesystem. The current codebase couples pixel math, manifest handling, and report generation with filesystem I/O. These two pure packages make the core logic reusable without duplication.

**Approach:** npm workspaces with `lib/` unchanged. The new packages contain copies of pure logic; root `lib/` files are not modified. A follow-up PR will refactor `lib/` to delegate to packages (shim pattern) and add `adapter-fs` + `adapter-report-md`.

## Changes

- **@snapdrift/manifest** — Pure manifest schema package:
  - `validateManifest()` with `schemaVersion` support (defaults to 1, per ADR)
  - `indexManifestEntries()` and `indexRouteResults()` (extracted from compare-results.mjs)
  - `viewportKey()` and `viewportHash()` for cross-provider viewport hashing
  - All types from `visual-diff-types.d.ts` plus new `CaptureProfile` and `ViewportDescriptor` types
  - Zero runtime dependencies, zero I/O

- **@snapdrift/compare-core** — Pure pixel comparison package:
  - `compareBuffers()` — buffer-based pixel comparison (extracted from `comparePngs`, minus filesystem I/O)
  - `generateDiffImage()` — **net-new** visual diff PNG rendering (ADR requirement)
  - `compareWithIgnoreRegions()` — **net-new** ignore-region masking before comparison (ADR requirement)
  - Returns ADR-convention shape: `{ pct, pixelsChanged, diffImageBuffer }` plus backward-compat aliases
  - Only dependency: `pngjs`

- **Infrastructure:**
  - Root `package.json` adds `"workspaces": ["packages/*"]` and workspace deps
  - Jest config discovers `packages/*/tests/`
  - ESLint config covers `packages/*/tests/`
  - `tsconfig.json` includes package paths

## Test plan

- [x] `npm ci` installs workspace packages correctly
- [x] `npm test` — 225 tests pass (14 suites), including new package tests
- [x] `npm run typecheck` — no type errors
- [x] `npm run lint` — no lint errors
- [x] `npm run validate:actions` — all 9 action YAML definitions valid
- [x] `npm run pack:check` — package bundles correctly
- [ ] Verify `lib/compare-results.mjs` behavior is unchanged (shim pattern not yet applied)
- [ ] Verify actions still resolve `ACTION_ROOT/lib/*.mjs` correctly

## Related

Closes #58 (Phase 1a — adapter packages follow in separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)