### PR TITLE
chore: bump versions for 0.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.4.0 - 2026-05-26
+
+### Features
+
+- **VisualProvider interface** — new `VisualProvider` interface (`capture`, `diff`, `publishBaseline`, `fetchLatestBaseline`, `buildCommentBody`) with `LocalProvider` and `SnapProvider` implementations. Config `provider` field (`"local"` | `"snap"`) selects the backend; defaults to `"local"` for zero-config backward compatibility.
+- **SnapProvider** — calls Snap's `/v1/visual/*` API for capture, diff, and baseline management. Retries on 5xx with exponential backoff (3 attempts, 30 s cap). Honors `snap.onUnavailable` (`"fail"` | `"warn-and-skip"` | `"fallback-local"`). 4xx errors never retry or fall back.
+- **Snap config** — new `snap` config block (`apiUrl`, `apiKeyEnv`/`apiKey`, `projectId`, `onUnavailable`) in `snapdrift.json`. Exactly one of `apiKeyEnv` or `apiKey` is required when `provider: "snap"`.
+- **PR comment unification** — both providers now produce identical PR comment markdown via a shared `buildCommentBody(summary, meta?)` method. `SnapProvider` appends a "View in dashboard →" link when `dashboardUrl` is present; `LocalProvider` omits it. Comment steps route through the provider instead of calling `buildReportCommentBody` directly, with a defensive fallback to `LocalProvider` if config loading fails.
+- **`migrate-baselines` command** — one-shot CLI command (`snapdrift migrate-baselines --to snap` / `--to local`) to upload local baselines to Snap or export Snap baselines back to a local directory. Supports `--accept-cross-engine` for engine-mismatch scenarios.
+- **`init --from-snap-action` codemod** — translates a Snap `github-action` workflow YAML into `snapdrift.json` with `provider: "snap"`. Emits structured warnings for features with no direct equivalent (jpeg format, baseline tags, single-shot artifact upload).
+
+### Infrastructure
+
+- **`@snapdrift/manifest` v1.1.0** — added `ProviderCommentMeta`, `dashboardUrl` on `VisualDiffSummary`, `buildCommentBody` on `VisualProvider`, `SnapConfig` re-export.
+- **`@snapdrift/adapter-report-md` v1.1.0** — `buildReportCommentBody` now accepts `dashboardUrl` in meta; renders "View in dashboard →" link when present and valid.
+- **Action contract tests** — `snapdrift-actions-contract` test suite now asserts that comment and pr-diff steps include `createProvider` and `buildCommentBody` calls.
+- **Provider unification tests** — new `buildCommentBody — provider unification` test block verifying identical markdown output across providers, dashboard link inclusion/exclusion, and URL validation.
+
 ## 0.3.0 - 2026-05-26
 
 ### Infrastructure

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snapdrift",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": false,
   "type": "module",
   "description": "SnapDrift captures, compares, and reports UI drift for Playwright-based app checks.",
@@ -96,9 +96,9 @@
   },
   "dependencies": {
     "@snapdrift/adapter-fs": "^1.0.0",
-    "@snapdrift/adapter-report-md": "^1.0.0",
+    "@snapdrift/adapter-report-md": "^1.1.0",
     "@snapdrift/compare-core": "^1.0.0",
-    "@snapdrift/manifest": "^1.0.0",
+    "@snapdrift/manifest": "^1.1.0",
     "js-yaml": "^4.1.0",
     "playwright": "^1.59.1",
     "pngjs": "^7.0.0"

--- a/packages/adapter-fs/package.json
+++ b/packages/adapter-fs/package.json
@@ -12,7 +12,7 @@
   "repository": { "type": "git", "url": "https://github.com/ranacseruet/snapdrift.git", "directory": "packages/adapter-fs" },
   "dependencies": {
     "@snapdrift/compare-core": "^1.0.0",
-    "@snapdrift/manifest": "^1.0.0",
+    "@snapdrift/manifest": "^1.1.0",
     "pngjs": "^7.0.0",
     "playwright": "^1.59.1"
   }

--- a/packages/adapter-report-md/package.json
+++ b/packages/adapter-report-md/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapdrift/adapter-report-md",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Pure markdown and HTML report generators for SnapDrift — zero runtime dependencies",
   "type": "module",
   "main": "src/index.mjs",

--- a/packages/manifest/package.json
+++ b/packages/manifest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapdrift/manifest",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "SnapDrift manifest schema, validation, and indexing — pure, zero I/O",
   "type": "module",
   "main": "src/index.mjs",


### PR DESCRIPTION
## Summary

- Version bumps for the phase 3 changes so that downstream consumers (Snap screenshot-api, phase 4 triage dashboard) can reference the new `ProviderCommentMeta`, `dashboardUrl`, and `buildCommentBody` additions.

### Packages bumped

| Package | Old | New | Why |
|---|---|---|---|
| `snapdrift` | 0.3.0 | 0.4.0 | Phase 3 features: VisualProvider, SnapProvider, PR comment unification, migrate-baselines, init codemod |
| `@snapdrift/manifest` | 1.0.0 | 1.1.0 | Added `ProviderCommentMeta`, `dashboardUrl` on `VisualDiffSummary`, `buildCommentBody` on `VisualProvider` |
| `@snapdrift/adapter-report-md` | 1.0.0 | 1.1.0 | Added `dashboardUrl` to `buildReportCommentBody` meta |

`@snapdrift/compare-core` and `@snapdrift/adapter-fs` stay at 1.0.0 (no phase 3 changes). `adapter-fs`'s `manifest` dep is bumped to `^1.1.0`.

### CHANGELOG

Full 0.4.0 entry added covering all phase 3 features and infrastructure changes.

## Test plan

- [x] 438 tests pass
- [x] Typecheck passes
- [x] `npm pack --dry-run` succeeds (publishability check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)