### PR TITLE
fix(snap-provider): fix API contract mismatches with Snap backend

### DIFF
--- a/lib/snap-provider.mjs
+++ b/lib/snap-provider.mjs
@@ -8,7 +8,7 @@ import path from 'node:path';
 
 import { makeMarkdown, buildReportCommentBody } from '@snapdrift/adapter-report-md';
 import { loadSnapdriftConfig } from '@snapdrift/adapter-fs';
-import { selectConfiguredRoutes, splitCommaList, determineDriftStatus } from '@snapdrift/manifest';
+import { selectConfiguredRoutes, splitCommaList, determineDriftStatus, VIEWPORT_PRESETS } from '@snapdrift/manifest';
 
 /** @typedef {import('../types/visual-diff-types').VisualProvider} VisualProvider */
 /** @typedef {import('../types/visual-diff-types').ProviderCaptureOptions} CaptureOptions */
@@ -109,27 +109,26 @@ export class SnapProvider {
     const { routes, selectedRouteIds } = selectConfiguredRoutes(config, requestedRouteIds);
 
     const idempotencyKey = this.#generateIdempotencyKey();
-    const runResponse = await this.#request('POST', `/v1/visual/projects/${this.#projectId}/runs`, {
-      idempotencyKey,
-      routes: routes.map((r) => ({
-        id: r.id,
-        path: r.path,
-        viewport: r.viewport,
-        changePaths: r.changePaths
-      })),
-      captureProfile: this.#buildCaptureProfile()
+    const runId = `run_${crypto.randomUUID().replace(/-/g, '').slice(0, 24)}`;
+    await this.#request('POST', `/v1/visual/projects/${this.#projectId}/runs`, {
+      id: runId,
+      baseUrl: config.baseUrl,
+      captureProfileJson: JSON.stringify(this.#buildCaptureProfile()),
+      trigger: 'ci',
     }, idempotencyKey);
-
-    const runId = runResponse.id;
 
     // Submit each route as a capture with its own idempotency key
     for (const route of routes) {
       const captureKey = this.#generateIdempotencyKey();
+      const captureId = `cap_${crypto.randomUUID().replace(/-/g, '').slice(0, 24)}`;
+      const viewportDescriptor = typeof route.viewport === 'string'
+        ? (VIEWPORT_PRESETS[route.viewport] ?? { width: 1280, height: 720 })
+        : route.viewport;
       await this.#request('POST', `/v1/visual/runs/${runId}/captures`, {
-        idempotencyKey: captureKey,
+        id: captureId,
         routeId: route.id,
         routePath: route.path,
-        viewport: route.viewport
+        viewportDescriptorJson: JSON.stringify(viewportDescriptor),
       }, captureKey);
     }
 
@@ -662,7 +661,7 @@ export class SnapProvider {
       missing,
       errors,
       dimensionChanges: [],
-      dashboardUrl: `${this.#apiUrl}/projects/${this.#projectId}/runs/${run.id}`
+      dashboardUrl: `${this.#apiUrl}/dashboard/visual/${this.#projectId}/runs/${run.id}`
     };
 
     summary.status = determineDriftStatus(summary);

--- a/tests/snap-provider.test.js
+++ b/tests/snap-provider.test.js
@@ -139,11 +139,28 @@ describe('SnapProvider.capture()', () => {
       expect(runPost).toBeDefined();
       expect(runPost.headers['Authorization']).toBe('Bearer test-api-key-1234');
       expect(runPost.headers['Idempotency-Key']).toBeDefined();
+      // id and captureProfileJson are required by the Snap API
+      expect(typeof runPost.body.id).toBe('string');
+      expect(runPost.body.id).toMatch(/^run_/);
+      expect(typeof runPost.body.captureProfileJson).toBe('string');
+      expect(() => JSON.parse(runPost.body.captureProfileJson)).not.toThrow();
+      // baseUrl must be forwarded so the render worker knows what to render
+      expect(runPost.body.baseUrl).toBe('http://localhost:3000');
 
       // Verify capture POST
       const capturePost = requests.find((r) => r.url.includes('/captures'));
       expect(capturePost).toBeDefined();
       expect(capturePost.headers['Authorization']).toBe('Bearer test-api-key-1234');
+      // id and viewportDescriptorJson are required by the Snap API
+      expect(typeof capturePost.body.id).toBe('string');
+      expect(capturePost.body.id).toMatch(/^cap_/);
+      expect(typeof capturePost.body.viewportDescriptorJson).toBe('string');
+      const parsedViewport = JSON.parse(capturePost.body.viewportDescriptorJson);
+      expect(typeof parsedViewport.width).toBe('number');
+      expect(typeof parsedViewport.height).toBe('number');
+      // "desktop" preset should expand to 1440×900
+      expect(parsedViewport.width).toBe(1440);
+      expect(parsedViewport.height).toBe(900);
     } finally {
       await fs.rm(configPath, { force: true });
     }


### PR DESCRIPTION
## Summary

Fixes all API contract mismatches between `SnapProvider` and the Snap API (`snap.i2dev.com`) that were preventing the end-to-end visual regression flow from working. Counterpart to i2Dev-com/snap#522.

## Changes

- **`id` field on run creation** — generate `run_<uuid>` and send in body (Snap API requires it for DB insert)
- **`id` field on capture creation** — generate `cap_<uuid>` and send in body
- **`captureProfileJson` (was `captureProfile`)** — rename field and JSON-stringify; Snap API expects a string
- **`viewportDescriptorJson` (was `viewport`)** — expand preset string (`"desktop"`, `"mobile"`) to full descriptor using `VIEWPORT_PRESETS` from `@snapdrift/manifest`, then JSON-stringify; Snap API expects `{"width":1440,"height":900,...}`
- **`baseUrl`** — forward `config.baseUrl` in run creation body so the Snap render worker can construct the full URL (`baseUrl + routePath`) for Playwright
- **Dashboard URL** — fix to `/dashboard/visual/${projectId}/runs/${runId}` (was `/projects/...`)
- **Tests** — assert all new required fields on run and capture POST bodies

## Test plan

- [x] `npm test` — 438 pass, 0 fail

## How this fits together

With snap PR #522 merged and workers enabled (`VISUAL_RENDER_WORKER_INTERVAL_MS=5000`, `VISUAL_DIFF_WORKER_INTERVAL_MS=5000`), the full automated flow becomes:

1. SnapProvider → `POST /v1/visual/projects/:id/runs` with `id`, `baseUrl`, `captureProfileJson`
2. SnapProvider → `POST /v1/visual/runs/:id/captures` per route with `id`, `viewportDescriptorJson`
3. Snap render worker polls `claim-render` → invokes `snap-lambda-renderer` → posts `render-result`
4. Snap diff worker polls `claim-diff` → invokes `snap-diff-lambda` → posts `diff-result`
5. SnapProvider polls `GET /v1/visual/runs/:id` (now embeds captures) → builds diff summary → posts PR comment with dashboard link

User config needed:
```json
{ "provider": "snap", "snap": { "apiKeyEnv": "SNAP_API_KEY", "projectId": "prj_..." } }
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)