### PR TITLE
fix: install action dependencies before scope/config steps

### DIFF
--- a/actions/baseline/action.yml
+++ b/actions/baseline/action.yml
@@ -51,6 +51,10 @@ runs:
       with:
         node-version: '22'
 
+    - name: Install action dependencies
+      shell: bash
+      run: npm ci --prefix "$ACTION_ROOT"
+
     - id: config
       shell: bash
       env:
@@ -67,10 +71,6 @@ runs:
 
         await fs.appendFile(process.env.GITHUB_OUTPUT, `artifact_name=${config.baselineArtifactName}\n`);
         EOF
-
-    - name: Install shared action dependencies
-      shell: bash
-      run: npm ci --prefix "$ACTION_ROOT"
 
     - name: Install Playwright Chromium
       shell: bash

--- a/actions/comment/action.yml
+++ b/actions/comment/action.yml
@@ -40,6 +40,15 @@ runs:
       shell: bash
       run: echo "ACTION_ROOT=$(cd "$GITHUB_ACTION_PATH/../.." && pwd)" >> "$GITHUB_ENV"
 
+    - name: Set up Node.js
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+      with:
+        node-version: '22'
+
+    - name: Install action dependencies
+      shell: bash
+      run: npm ci --prefix "$ACTION_ROOT"
+
     - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
       env:
         VISUAL_DIFF_SUMMARY_PATH: ${{ inputs.summary-path }}

--- a/actions/pr-diff/action.yml
+++ b/actions/pr-diff/action.yml
@@ -95,6 +95,10 @@ runs:
       with:
         node-version: '22'
 
+    - name: Install action dependencies
+      shell: bash
+      run: npm ci --prefix "$ACTION_ROOT"
+
     - id: context
       uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
       env:
@@ -288,11 +292,6 @@ runs:
           echo "run_dir=${GITHUB_WORKSPACE}/snapdrift-baseline-download"
           echo "screenshots_dir=$(dirname "$MANIFEST_FILE")/screenshots"
         } >> "$GITHUB_OUTPUT"
-
-    - name: Install shared action dependencies
-      if: steps.scope.outputs.should_run == 'true'
-      shell: bash
-      run: npm ci --prefix "$ACTION_ROOT"
 
     - name: Install Playwright Chromium
       if: steps.scope.outputs.should_run == 'true'

--- a/actions/scope/action.yml
+++ b/actions/scope/action.yml
@@ -40,6 +40,15 @@ runs:
       shell: bash
       run: echo "ACTION_ROOT=$(cd "$GITHUB_ACTION_PATH/../.." && pwd)" >> "$GITHUB_ENV"
 
+    - name: Set up Node.js
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+      with:
+        node-version: '22'
+
+    - name: Install action dependencies
+      shell: bash
+      run: npm ci --prefix "$ACTION_ROOT"
+
     - id: scope
       uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
       env:


### PR DESCRIPTION
## Problem

`lib/snapdrift-config.mjs` has a **static top-level** `export { ... } from '@snapdrift/manifest'`. Any step that imports this module at load time fails with:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@snapdrift/manifest'
imported from .../lib/snapdrift-config.mjs
```

...when `node_modules` haven't been installed yet.

The `npm ci` step was gated behind `if: steps.scope.outputs.should_run == 'true'`, but the `scope`/`config` steps that produce `should_run` need `@snapdrift/manifest` already installed — a classic chicken-and-egg failure.

Observed in the field: `ranacseruet/demo.codesamplez.com` PR #90, action run [26651668101](https://github.com/ranacseruet/demo.codesamplez.com/actions/runs/26651668101).

## Fix

Move `npm ci` to run **unconditionally**, immediately after `setup-node`, before any step that imports from `lib/*.mjs`.

The Playwright install remains conditional since Playwright is only needed when captures actually run.

## Affected actions

| Action | Issue |
|---|---|
| `pr-diff` | `scope` step imports `snapdrift-config.mjs` before `npm ci` |
| `scope` | standalone action had no `npm ci` at all |
| `baseline` | `config` step imports `snapdrift-config.mjs` before `npm ci` |
| `comment` | imports `snapdrift-config.mjs` with no prior `npm ci` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)