### PR TITLE
fix: wire configured provider into pr-diff capture and compare steps

### DIFF
--- a/actions/pr-diff/action.yml
+++ b/actions/pr-diff/action.yml
@@ -317,12 +317,32 @@ runs:
         const { loadSnapdriftConfig, splitCommaList } = await import(pathToFileURL(configModulePath));
 
         const { config } = await loadSnapdriftConfig(process.env.REPO_CONFIG_PATH || undefined);
+        const { createProvider, SnapSkipError, SnapFallbackError } = await import(pathToFileURL(providerModulePath));
         const provider = createProvider(config.provider || 'local', config);
 
-        const result = await provider.capture({
-          configPath: process.env.REPO_CONFIG_PATH || undefined,
-          routeIds: splitCommaList(process.env.ROUTE_IDS)
-        });
+        let result;
+        try {
+          result = await provider.capture({
+            configPath: process.env.REPO_CONFIG_PATH || undefined,
+            routeIds: splitCommaList(process.env.ROUTE_IDS)
+          });
+        } catch (err) {
+          if (err instanceof SnapSkipError) {
+            process.stderr.write(`[SnapDrift] Snap unavailable — skipping visual regression (warn-and-skip).\n`);
+            await fs.appendFile(process.env.GITHUB_OUTPUT, `provider=skipped\n`);
+            process.exit(0);
+          }
+          if (err instanceof SnapFallbackError) {
+            process.stderr.write(`[SnapDrift] Snap unavailable — falling back to local provider.\n`);
+            const { createProvider: cp2 } = await import(pathToFileURL(providerModulePath));
+            result = await cp2('local', config).capture({
+              configPath: process.env.REPO_CONFIG_PATH || undefined,
+              routeIds: splitCommaList(process.env.ROUTE_IDS)
+            });
+          } else {
+            throw err;
+          }
+        }
 
         const outputs = [
           `provider=${config.provider || 'local'}`,
@@ -336,7 +356,7 @@ runs:
         EOF
 
     - id: compare
-      if: steps.scope.outputs.should_run == 'true' && (steps.baseline.outputs.found == 'true' || steps.capture.outputs.provider == 'snap')
+      if: steps.scope.outputs.should_run == 'true' && steps.capture.outputs.provider != 'skipped' && (steps.baseline.outputs.found == 'true' || steps.capture.outputs.provider == 'snap')
       shell: bash
       env:
         REPO_CONFIG_PATH: ${{ inputs.repo-config-path }}
@@ -356,7 +376,7 @@ runs:
 
         const providerModulePath = path.resolve(process.env.ACTION_ROOT, 'lib/provider.mjs');
         const configModulePath = path.resolve(process.env.ACTION_ROOT, 'lib/snapdrift-config.mjs');
-        const { createProvider } = await import(pathToFileURL(providerModulePath));
+        const { createProvider, SnapSkipError, SnapFallbackError } = await import(pathToFileURL(providerModulePath));
         const { loadSnapdriftConfig, splitCommaList } = await import(pathToFileURL(configModulePath));
 
         const { config } = await loadSnapdriftConfig(process.env.REPO_CONFIG_PATH || undefined);
@@ -366,7 +386,7 @@ runs:
         const resolvedSummaryPath = path.join(resolvedOutDir, 'summary.json');
         const resolvedMarkdownPath = path.join(resolvedOutDir, 'summary.md');
 
-        const { summary, markdown } = await provider.diff({
+        const diffOptions = {
           configPath: process.env.REPO_CONFIG_PATH || undefined,
           baselineResultsPath: process.env.BASELINE_RESULTS_PATH || undefined,
           baselineManifestPath: process.env.BASELINE_MANIFEST_PATH || undefined,
@@ -376,7 +396,25 @@ runs:
           baselineSourceSha: process.env.BASELINE_SOURCE_SHA || undefined,
           currentResultsPath: process.env.CURRENT_RESULTS_PATH || undefined,
           currentManifestPath: process.env.CURRENT_MANIFEST_PATH || undefined
-        });
+        };
+
+        let diffResult;
+        try {
+          diffResult = await provider.diff(diffOptions);
+        } catch (err) {
+          if (err instanceof SnapSkipError) {
+            process.stderr.write(`[SnapDrift] Snap unavailable during diff — skipping (warn-and-skip).\n`);
+            process.exit(0);
+          }
+          if (err instanceof SnapFallbackError) {
+            process.stderr.write(`[SnapDrift] Snap unavailable during diff — falling back to local provider.\n`);
+            const { createProvider: cp2 } = await import(pathToFileURL(providerModulePath));
+            diffResult = await cp2('local', config).diff(diffOptions);
+          } else {
+            throw err;
+          }
+        }
+        const { summary, markdown } = diffResult;
 
         await fs.mkdir(resolvedOutDir, { recursive: true });
         await Promise.all([
@@ -610,7 +648,7 @@ runs:
             });
           }
 
-    - if: steps.scope.outputs.should_run == 'true' && steps.baseline.outputs.found == 'true'
+    - if: steps.scope.outputs.should_run == 'true' && steps.capture.outputs.provider != 'skipped' && (steps.baseline.outputs.found == 'true' || steps.capture.outputs.provider == 'snap')
       shell: bash
       run: |
         node --input-type=module <<'EOF'

--- a/actions/pr-diff/action.yml
+++ b/actions/pr-diff/action.yml
@@ -311,17 +311,21 @@ runs:
         import path from 'node:path';
         import { pathToFileURL } from 'node:url';
 
-        const captureModulePath = path.resolve(process.env.ACTION_ROOT, 'lib/capture-routes.mjs');
+        const providerModulePath = path.resolve(process.env.ACTION_ROOT, 'lib/provider.mjs');
         const configModulePath = path.resolve(process.env.ACTION_ROOT, 'lib/snapdrift-config.mjs');
-        const { runBaselineCapture } = await import(pathToFileURL(captureModulePath));
-        const { splitCommaList } = await import(pathToFileURL(configModulePath));
+        const { createProvider } = await import(pathToFileURL(providerModulePath));
+        const { loadSnapdriftConfig, splitCommaList } = await import(pathToFileURL(configModulePath));
 
-        const result = await runBaselineCapture({
+        const { config } = await loadSnapdriftConfig(process.env.REPO_CONFIG_PATH || undefined);
+        const provider = createProvider(config.provider || 'local', config);
+
+        const result = await provider.capture({
           configPath: process.env.REPO_CONFIG_PATH || undefined,
           routeIds: splitCommaList(process.env.ROUTE_IDS)
         });
 
         const outputs = [
+          `provider=${config.provider || 'local'}`,
           `results_file=${result.resultsPath}`,
           `manifest_file=${result.manifestPath}`,
           `screenshots_root=${result.screenshotsRoot}`,
@@ -332,7 +336,7 @@ runs:
         EOF
 
     - id: compare
-      if: steps.scope.outputs.should_run == 'true' && steps.baseline.outputs.found == 'true'
+      if: steps.scope.outputs.should_run == 'true' && (steps.baseline.outputs.found == 'true' || steps.capture.outputs.provider == 'snap')
       shell: bash
       env:
         REPO_CONFIG_PATH: ${{ inputs.repo-config-path }}
@@ -342,22 +346,27 @@ runs:
         BASELINE_RUN_DIR: ${{ steps.baseline_paths.outputs.run_dir }}
         BASELINE_ARTIFACT_NAME: ${{ steps.baseline.outputs.artifact_name }}
         BASELINE_SOURCE_SHA: ${{ steps.baseline.outputs.head_sha }}
+        CURRENT_RESULTS_PATH: ${{ steps.capture.outputs.results_file }}
+        CURRENT_MANIFEST_PATH: ${{ steps.capture.outputs.manifest_file }}
       run: |
         node --input-type=module <<'EOF'
         import fs from 'node:fs/promises';
         import path from 'node:path';
         import { pathToFileURL } from 'node:url';
 
-        const compareModulePath = path.resolve(process.env.ACTION_ROOT, 'lib/compare-results.mjs');
+        const providerModulePath = path.resolve(process.env.ACTION_ROOT, 'lib/provider.mjs');
         const configModulePath = path.resolve(process.env.ACTION_ROOT, 'lib/snapdrift-config.mjs');
-        const { runDriftCheckCli } = await import(pathToFileURL(compareModulePath));
-        const { splitCommaList } = await import(pathToFileURL(configModulePath));
+        const { createProvider } = await import(pathToFileURL(providerModulePath));
+        const { loadSnapdriftConfig, splitCommaList } = await import(pathToFileURL(configModulePath));
+
+        const { config } = await loadSnapdriftConfig(process.env.REPO_CONFIG_PATH || undefined);
+        const provider = createProvider(config.provider || 'local', config);
 
         const resolvedOutDir = path.resolve('qa-artifacts/snapdrift/drift/current');
         const resolvedSummaryPath = path.join(resolvedOutDir, 'summary.json');
         const resolvedMarkdownPath = path.join(resolvedOutDir, 'summary.md');
 
-        await runDriftCheckCli({
+        const { summary, markdown } = await provider.diff({
           configPath: process.env.REPO_CONFIG_PATH || undefined,
           baselineResultsPath: process.env.BASELINE_RESULTS_PATH || undefined,
           baselineManifestPath: process.env.BASELINE_MANIFEST_PATH || undefined,
@@ -365,10 +374,16 @@ runs:
           routeIds: splitCommaList(process.env.ROUTE_IDS),
           baselineArtifactName: process.env.BASELINE_ARTIFACT_NAME || undefined,
           baselineSourceSha: process.env.BASELINE_SOURCE_SHA || undefined,
-          enforceOutcome: false
+          currentResultsPath: process.env.CURRENT_RESULTS_PATH || undefined,
+          currentManifestPath: process.env.CURRENT_MANIFEST_PATH || undefined
         });
 
-        const summary = JSON.parse(await fs.readFile(resolvedSummaryPath, 'utf8'));
+        await fs.mkdir(resolvedOutDir, { recursive: true });
+        await Promise.all([
+          fs.writeFile(resolvedSummaryPath, JSON.stringify(summary, null, 2)),
+          fs.writeFile(resolvedMarkdownPath, markdown)
+        ]);
+
         const outputs = [
           `summary_path=${resolvedSummaryPath}`,
           `markdown_path=${resolvedMarkdownPath}`,
@@ -407,7 +422,7 @@ runs:
         EOF
 
     - id: skipped_baseline
-      if: steps.scope.outputs.should_run == 'true' && steps.baseline.outputs.found != 'true'
+      if: steps.scope.outputs.should_run == 'true' && steps.baseline.outputs.found != 'true' && steps.capture.outputs.provider != 'snap'
       shell: bash
       env:
         MESSAGE: ${{ steps.baseline.outputs.message }}


### PR DESCRIPTION
## Problem

The `pr-diff` action's capture and compare steps were hardcoded to always use local Playwright, regardless of the configured `provider`:

- **capture**: called `runBaselineCapture` directly (always local Playwright)
- **compare**: called `runDriftCheckCli` directly (always local pixel diff)

Setting `provider: "snap"` in `snapdrift.json` had no effect on actual capture/diff — it only changed the PR comment body format. Nothing was ever submitted to the snap cloud API.

## Fix

Both steps now load the config and call through `createProvider()`:

**capture** — `provider.capture(options)`:
- `local`: unchanged, runs Playwright locally
- `snap`: creates a run on snap API, submits captures, returns run metadata (runId) for the diff step to poll

**compare** — `provider.diff(options)`:
- `local`: unchanged, local pixel diff
- `snap`: polls `GET /v1/visual/runs/:id` until terminal, maps to summary

Also adds `CURRENT_RESULTS_PATH` + `CURRENT_MANIFEST_PATH` env vars to the compare step (snap's `diff()` reads the runId from the capture metadata file).

The compare step condition is extended to also run when `provider == 'snap'` — snap manages its own baselines, so the GitHub Actions artifact baseline is not required for snap runs.

## Testing

Once merged, a PR on a repo with `provider: "snap"` configured will submit runs to `snap.i2dev.com` and poll for results. The snap dashboard at `/dashboard/visual/:projectId` will show the runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)