### PR TITLE
feat: wire snap provider into baseline action

### DIFF
--- a/actions/baseline/action.yml
+++ b/actions/baseline/action.yml
@@ -69,10 +69,15 @@ runs:
         const { loadSnapdriftConfig } = await import(pathToFileURL(modulePath));
         const { config } = await loadSnapdriftConfig(process.env.REPO_CONFIG_PATH || undefined);
 
-        await fs.appendFile(process.env.GITHUB_OUTPUT, `artifact_name=${config.baselineArtifactName}\n`);
+        const outputs = [
+          `artifact_name=${config.baselineArtifactName}`,
+          `provider=${config.provider || 'local'}`
+        ].join('\n') + '\n';
+        await fs.appendFile(process.env.GITHUB_OUTPUT, outputs);
         EOF
 
     - name: Install Playwright Chromium
+      if: steps.config.outputs.provider != 'snap'
       shell: bash
       run: |
         "$ACTION_ROOT/node_modules/.bin/playwright" install --with-deps chromium
@@ -88,17 +93,40 @@ runs:
         import path from 'node:path';
         import { pathToFileURL } from 'node:url';
 
-        const captureModulePath = path.resolve(process.env.ACTION_ROOT, 'lib/capture-routes.mjs');
+        const providerModulePath = path.resolve(process.env.ACTION_ROOT, 'lib/provider.mjs');
         const configModulePath = path.resolve(process.env.ACTION_ROOT, 'lib/snapdrift-config.mjs');
-        const { runBaselineCapture } = await import(pathToFileURL(captureModulePath));
-        const { splitCommaList } = await import(pathToFileURL(configModulePath));
+        const { createProvider, SnapSkipError, SnapFallbackError } = await import(pathToFileURL(providerModulePath));
+        const { loadSnapdriftConfig, splitCommaList } = await import(pathToFileURL(configModulePath));
 
-        const result = await runBaselineCapture({
-          configPath: process.env.REPO_CONFIG_PATH || undefined,
-          routeIds: splitCommaList(process.env.ROUTE_IDS)
-        });
+        const { config } = await loadSnapdriftConfig(process.env.REPO_CONFIG_PATH || undefined);
+        const provider = createProvider(config.provider || 'local', config);
+
+        let result;
+        try {
+          result = await provider.capture({
+            configPath: process.env.REPO_CONFIG_PATH || undefined,
+            routeIds: splitCommaList(process.env.ROUTE_IDS)
+          });
+        } catch (err) {
+          if (err instanceof SnapSkipError) {
+            process.stderr.write(`[SnapDrift] Snap unavailable — skipping baseline capture (warn-and-skip).\n`);
+            await fs.appendFile(process.env.GITHUB_OUTPUT, `provider=skipped\n`);
+            process.exit(0);
+          }
+          if (err instanceof SnapFallbackError) {
+            process.stderr.write(`[SnapDrift] Snap unavailable — falling back to local provider.\n`);
+            const { createProvider: cp2 } = await import(pathToFileURL(providerModulePath));
+            result = await cp2('local', config).capture({
+              configPath: process.env.REPO_CONFIG_PATH || undefined,
+              routeIds: splitCommaList(process.env.ROUTE_IDS)
+            });
+          } else {
+            throw err;
+          }
+        }
 
         const outputs = [
+          `provider=${config.provider || 'local'}`,
           `results_file=${result.resultsPath}`,
           `manifest_file=${result.manifestPath}`,
           `screenshots_root=${result.screenshotsRoot}`,
@@ -108,7 +136,34 @@ runs:
         await fs.appendFile(process.env.GITHUB_OUTPUT, outputs);
         EOF
 
+    - id: publish
+      if: steps.capture.outputs.provider == 'snap'
+      shell: bash
+      env:
+        REPO_CONFIG_PATH: ${{ inputs.repo-config-path }}
+        RESULTS_PATH: ${{ steps.capture.outputs.results_file }}
+      run: |
+        node --input-type=module <<'EOF'
+        import path from 'node:path';
+        import { pathToFileURL } from 'node:url';
+
+        const providerModulePath = path.resolve(process.env.ACTION_ROOT, 'lib/provider.mjs');
+        const configModulePath = path.resolve(process.env.ACTION_ROOT, 'lib/snapdrift-config.mjs');
+        const { createProvider } = await import(pathToFileURL(providerModulePath));
+        const { loadSnapdriftConfig } = await import(pathToFileURL(configModulePath));
+
+        const { config } = await loadSnapdriftConfig(process.env.REPO_CONFIG_PATH || undefined);
+        const provider = createProvider('snap', config);
+
+        await provider.publishBaseline({
+          resultsPath: process.env.RESULTS_PATH || undefined
+        });
+
+        process.stdout.write('[SnapDrift] Snap baseline published successfully.\n');
+        EOF
+
     - id: stage
+      if: steps.capture.outputs.provider != 'snap' && steps.capture.outputs.provider != 'skipped'
       shell: bash
       env:
         RESULTS_PATH: ${{ steps.capture.outputs.results_file }}
@@ -133,7 +188,7 @@ runs:
         await fs.appendFile(process.env.GITHUB_OUTPUT, `bundle_dir=${result.bundleDir}\n`);
         EOF
 
-    - if: inputs.upload-artifact == 'true'
+    - if: inputs.upload-artifact == 'true' && steps.capture.outputs.provider != 'snap' && steps.capture.outputs.provider != 'skipped'
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
         name: ${{ steps.config.outputs.artifact_name }}

--- a/actions/baseline/action.yml
+++ b/actions/baseline/action.yml
@@ -71,13 +71,14 @@ runs:
 
         const outputs = [
           `artifact_name=${config.baselineArtifactName}`,
-          `provider=${config.provider || 'local'}`
+          `provider=${config.provider || 'local'}`,
+          `on_unavailable=${config.snap?.onUnavailable || 'fail'}`
         ].join('\n') + '\n';
         await fs.appendFile(process.env.GITHUB_OUTPUT, outputs);
         EOF
 
     - name: Install Playwright Chromium
-      if: steps.config.outputs.provider != 'snap'
+      if: steps.config.outputs.provider != 'snap' || steps.config.outputs.on_unavailable == 'fallback-local'
       shell: bash
       run: |
         "$ACTION_ROOT/node_modules/.bin/playwright" install --with-deps chromium
@@ -120,6 +121,16 @@ runs:
               configPath: process.env.REPO_CONFIG_PATH || undefined,
               routeIds: splitCommaList(process.env.ROUTE_IDS)
             });
+            // Report as local so publish is skipped and stage/upload run instead
+            const outputs = [
+              `provider=local`,
+              `results_file=${result.resultsPath}`,
+              `manifest_file=${result.manifestPath}`,
+              `screenshots_root=${result.screenshotsRoot}`,
+              `selected_route_ids=${result.selectedRouteIds.join(',')}`
+            ].join('\n') + '\n';
+            await fs.appendFile(process.env.GITHUB_OUTPUT, outputs);
+            process.exit(0);
           } else {
             throw err;
           }

--- a/lib/snap-provider.mjs
+++ b/lib/snap-provider.mjs
@@ -224,12 +224,34 @@ export class SnapProvider {
 
         // Poll until the run reaches a terminal state (renders + auto-diffs finish)
         const run = await this.#pollRun(runId);
+
+        if (run.status === 'error') {
+          throw new Error(
+            `Snap baseline run ${runId} ended with status "error" — cannot publish baseline. ` +
+            `Check the snap dashboard for capture error details.`
+          );
+        }
+
         const captures = run.captures ?? [];
+        const rendered = captures.filter((c) => c.currentObjectKey);
+
+        if (rendered.length === 0) {
+          throw new Error(
+            `Snap baseline run ${runId} completed but no captures produced a screenshot ` +
+            `(${captures.length} capture(s) found, 0 rendered). Cannot publish an empty baseline.`
+          );
+        }
+
+        if (rendered.length < captures.length) {
+          const failed = captures.length - rendered.length;
+          process.stderr.write(
+            `[SnapDrift] Warning: ${failed} of ${captures.length} capture(s) did not produce ` +
+            `a screenshot and will be excluded from the baseline.\n`
+          );
+        }
 
         // Build a manifest from the rendered captures
-        const routes = captures
-          .filter((c) => c.currentObjectKey)
-          .map((c) => ({
+        const routes = rendered.map((c) => ({
             routeId: c.routeId,
             routePath: c.routePath,
             viewportDescriptorJson: c.viewportDescriptorJson,

--- a/lib/snap-provider.mjs
+++ b/lib/snap-provider.mjs
@@ -198,21 +198,80 @@ export class SnapProvider {
   /**
    * Publish a baseline to Snap.
    *
+   * When called with a `resultsPath` that contains a `runId` (written by
+   * `capture()`), this method polls the run until all renders complete, then
+   * creates a snap baseline from the captured S3 keys. This is the primary
+   * path used by the baseline action with `provider: "snap"`.
+   *
    * @param {PublishBaselineOptions} options
    * @returns {Promise<PublishBaselineResult>}
    */
   async publishBaseline(options) {
+    const resultsPath = options.resultsPath
+      ?? (options.bundleDir ? path.join(path.resolve(options.bundleDir), 'results.json') : undefined);
+
+    // Snap-native baseline: poll the run that capture() submitted, then
+    // create a baseline from the rendered S3 keys.
+    if (resultsPath) {
+      let metadata;
+      try {
+        metadata = JSON.parse(await fs.readFile(resultsPath, 'utf-8'));
+      } catch { /* fall through to legacy path */ }
+
+      if (metadata?.runId) {
+        const { runId } = metadata;
+        const idempotencyKey = `baseline-${runId}`;
+
+        // Poll until the run reaches a terminal state (renders + auto-diffs finish)
+        const run = await this.#pollRun(runId);
+        const captures = run.captures ?? [];
+
+        // Build a manifest from the rendered captures
+        const routes = captures
+          .filter((c) => c.currentObjectKey)
+          .map((c) => ({
+            routeId: c.routeId,
+            routePath: c.routePath,
+            viewportDescriptorJson: c.viewportDescriptorJson,
+            objectKey: c.currentObjectKey
+          }));
+
+        const manifestJson = JSON.stringify({
+          schemaVersion: 1,
+          sourceRunId: runId,
+          routes
+        });
+
+        const baselineId = `bsl_${crypto.randomUUID().replace(/-/g, '').slice(0, 24)}`;
+        await this.#request(
+          'POST',
+          `/v1/visual/projects/${this.#projectId}/baselines`,
+          {
+            id: baselineId,
+            refBranch: process.env.GITHUB_REF_NAME || process.env.GITHUB_HEAD_REF || 'main',
+            refSha: process.env.GITHUB_SHA || 'unknown',
+            manifestJson,
+            captureProfileJson: JSON.stringify(this.#buildCaptureProfile())
+          },
+          idempotencyKey
+        );
+
+        const bundleDir = await fs.mkdtemp(path.join(os.tmpdir(), 'snapdrift-snap-baseline-'));
+        return { bundleDir };
+      }
+    }
+
+    // Legacy / migration path: bundle dir with pre-built results/manifest
     const idempotencyKey = this.#generateIdempotencyKey();
     const body = { idempotencyKey };
 
-    // If a bundle directory is provided, read files from it
     if (options.bundleDir) {
       const bundleDir = path.resolve(options.bundleDir);
-      const resultsPath = options.resultsPath || path.join(bundleDir, 'results.json');
+      const bResultsPath = options.resultsPath || path.join(bundleDir, 'results.json');
       const manifestPath = options.manifestPath || path.join(bundleDir, 'manifest.json');
 
       try {
-        const results = JSON.parse(await fs.readFile(resultsPath, 'utf-8'));
+        const results = JSON.parse(await fs.readFile(bResultsPath, 'utf-8'));
         body.results = results;
       } catch { /* results.json may not exist */ }
 
@@ -221,7 +280,6 @@ export class SnapProvider {
         body.manifest = manifest;
       } catch { /* manifest.json may not exist */ }
 
-      // If results contain a runId, use it for idempotency
       if (body.results?.runId) {
         body.idempotencyKey = `baseline-${body.results.runId}`;
       }


### PR DESCRIPTION
## Problem

The `baseline` action was hardcoded to local Playwright regardless of the configured `provider`. After PR #76 wired the snap provider into `pr-diff`, the baseline action remained local-only — so for `provider: "snap"`, no snap-side baseline was ever published, and comparisons had nothing to compare against.

## What changes

### `actions/baseline/action.yml`

| Step | Before | After |
|---|---|---|
| `config` | reads artifact name | also outputs `provider` |
| `Install Playwright Chromium` | always | only when `provider != 'snap'` |
| `capture` | hardcoded `runBaselineCapture` | `provider.capture()` with `SnapSkipError`/`SnapFallbackError` handling |
| `publish` (new) | — | runs when `provider == 'snap'`; calls `provider.publishBaseline()` |
| `stage` | always | only when `provider != 'snap'` |
| `upload-artifact` | always | only when `provider != 'snap'` |

### `lib/snap-provider.mjs` — `publishBaseline()`

When called with a `resultsPath` containing a `runId` (written by `capture()`):

1. Polls `GET /v1/visual/runs/:runId` until renders complete (run reaches terminal state)
2. Extracts `currentObjectKey` from each capture → builds `manifestJson`
3. POSTs `POST /v1/visual/projects/:id/baselines` with `refBranch`/`refSha` from `GITHUB_REF_NAME`/`GITHUB_SHA`

The snap baseline is now a real, traceable record linked to the commit that produced it.

## End-to-end flow with `provider: "snap"`

```
main push
  └─ baseline action
       capture()     → POST /v1/visual/projects/:id/runs + captures
       [snap workers render screenshots]
       publishBaseline() → polls run → builds manifest → POST /v1/visual/projects/:id/baselines
  └─ pr-diff action (on main, scope = missing_pr_number → run all)
       capture()     → same snap run submission
       diff()        → polls run → maps to summary
```

```
PR push (files matching changePaths)
  └─ pr-diff action
       capture()     → snap run submission
       diff()        → polls snap run → compares against baseline published above
       enforce       → fails CI if drift found (per diff.mode)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)