### PR TITLE
fix: skip Playwright install in pr-diff when provider is snap

### DIFF
--- a/actions/pr-diff/action.yml
+++ b/actions/pr-diff/action.yml
@@ -293,8 +293,28 @@ runs:
           echo "screenshots_dir=$(dirname "$MANIFEST_FILE")/screenshots"
         } >> "$GITHUB_OUTPUT"
 
-    - name: Install Playwright Chromium
+    - id: config
       if: steps.scope.outputs.should_run == 'true'
+      shell: bash
+      env:
+        REPO_CONFIG_PATH: ${{ inputs.repo-config-path }}
+      run: |
+        node --input-type=module <<'EOF'
+        import fs from 'node:fs/promises';
+        import path from 'node:path';
+        import { pathToFileURL } from 'node:url';
+        const configModulePath = path.resolve(process.env.ACTION_ROOT, 'lib/snapdrift-config.mjs');
+        const { loadSnapdriftConfig } = await import(pathToFileURL(configModulePath));
+        const { config } = await loadSnapdriftConfig(process.env.REPO_CONFIG_PATH || undefined);
+        const outputs = [
+          `provider=${config.provider || 'local'}`,
+          `on_unavailable=${config.snap?.onUnavailable || 'fail'}`
+        ].join('\n') + '\n';
+        await fs.appendFile(process.env.GITHUB_OUTPUT, outputs);
+        EOF
+
+    - name: Install Playwright Chromium
+      if: steps.scope.outputs.should_run == 'true' && (steps.config.outputs.provider != 'snap' || steps.config.outputs.on_unavailable == 'fallback-local')
       shell: bash
       run: |
         "$ACTION_ROOT/node_modules/.bin/playwright" install --with-deps chromium


### PR DESCRIPTION
## Problem

When `provider: \"snap\"` is configured, the pr-diff action still downloads and installs Playwright Chromium (~300 MB, ~2 min) before the capture step, even though snap renders server-side and the local browser is never used.

The `baseline` action already handles this correctly with a `config` step that reads the provider before Playwright is installed. The `pr-diff` action was missing the same pattern.

## Fix

Add a `config` step between `baseline_paths` and `Install Playwright Chromium` that reads `provider` and `on_unavailable` from the snapdrift config. Playwright is then gated on:

```
provider != 'snap' || on_unavailable == 'fallback-local'
```

The fallback-local carve-out ensures Playwright is still available if snap becomes unreachable and the action falls back to local capture.

## Impact

- Snap runs: Playwright install step is **skipped** (~2 min saved per run)
- Local runs: no change
- Snap + `onUnavailable: fallback-local`: Playwright still installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)