### PR TITLE
Add Snap local capture hybrid support

### DIFF
--- a/actions/baseline/action.yml
+++ b/actions/baseline/action.yml
@@ -66,19 +66,22 @@ runs:
         import { pathToFileURL } from 'node:url';
 
         const modulePath = path.resolve(process.env.ACTION_ROOT, 'lib/snapdrift-config.mjs');
+        const providerModulePath = path.resolve(process.env.ACTION_ROOT, 'lib/provider.mjs');
         const { loadSnapdriftConfig } = await import(pathToFileURL(modulePath));
+        const { isLocalBaseUrl } = await import(pathToFileURL(providerModulePath));
         const { config } = await loadSnapdriftConfig(process.env.REPO_CONFIG_PATH || undefined);
 
         const outputs = [
           `artifact_name=${config.baselineArtifactName}`,
           `provider=${config.provider || 'local'}`,
-          `on_unavailable=${config.snap?.onUnavailable || 'fail'}`
+          `on_unavailable=${config.snap?.onUnavailable || 'fail'}`,
+          `snap_local_capture=${(config.provider || 'local') === 'snap' && isLocalBaseUrl(config.baseUrl) ? 'true' : 'false'}`
         ].join('\n') + '\n';
         await fs.appendFile(process.env.GITHUB_OUTPUT, outputs);
         EOF
 
     - name: Install Playwright Chromium
-      if: steps.config.outputs.provider != 'snap' || steps.config.outputs.on_unavailable == 'fallback-local'
+      if: steps.config.outputs.provider != 'snap' || steps.config.outputs.on_unavailable == 'fallback-local' || steps.config.outputs.snap_local_capture == 'true'
       shell: bash
       run: |
         "$ACTION_ROOT/node_modules/.bin/playwright" install --with-deps chromium

--- a/actions/pr-diff/action.yml
+++ b/actions/pr-diff/action.yml
@@ -304,17 +304,20 @@ runs:
         import path from 'node:path';
         import { pathToFileURL } from 'node:url';
         const configModulePath = path.resolve(process.env.ACTION_ROOT, 'lib/snapdrift-config.mjs');
+        const providerModulePath = path.resolve(process.env.ACTION_ROOT, 'lib/provider.mjs');
         const { loadSnapdriftConfig } = await import(pathToFileURL(configModulePath));
+        const { isLocalBaseUrl } = await import(pathToFileURL(providerModulePath));
         const { config } = await loadSnapdriftConfig(process.env.REPO_CONFIG_PATH || undefined);
         const outputs = [
           `provider=${config.provider || 'local'}`,
-          `on_unavailable=${config.snap?.onUnavailable || 'fail'}`
+          `on_unavailable=${config.snap?.onUnavailable || 'fail'}`,
+          `snap_local_capture=${(config.provider || 'local') === 'snap' && isLocalBaseUrl(config.baseUrl) ? 'true' : 'false'}`
         ].join('\n') + '\n';
         await fs.appendFile(process.env.GITHUB_OUTPUT, outputs);
         EOF
 
     - name: Install Playwright Chromium
-      if: steps.scope.outputs.should_run == 'true' && (steps.config.outputs.provider != 'snap' || steps.config.outputs.on_unavailable == 'fallback-local')
+      if: steps.scope.outputs.should_run == 'true' && (steps.config.outputs.provider != 'snap' || steps.config.outputs.on_unavailable == 'fallback-local' || steps.config.outputs.snap_local_capture == 'true')
       shell: bash
       run: |
         "$ACTION_ROOT/node_modules/.bin/playwright" install --with-deps chromium

--- a/lib/provider.mjs
+++ b/lib/provider.mjs
@@ -2,7 +2,7 @@
 
 import { runBaselineCapture, generateDriftReport, stageArtifacts } from '@snapdrift/adapter-fs';
 import { buildReportCommentBody } from '@snapdrift/adapter-report-md';
-import { SnapProvider, SnapApiError, SnapUnavailableError, SnapFallbackError, SnapSkipError } from './snap-provider.mjs';
+import { SnapProvider, SnapApiError, SnapUnavailableError, SnapFallbackError, SnapSkipError, isLocalBaseUrl } from './snap-provider.mjs';
 
 /** @typedef {import('../types/visual-diff-types').VisualProvider} VisualProvider */
 /** @typedef {import('../types/visual-diff-types').ProviderCaptureOptions} CaptureOptions */
@@ -103,4 +103,4 @@ export function createProvider(providerName, config) {
   return factory(config);
 }
 
-export { SnapProvider, SnapApiError, SnapUnavailableError, SnapFallbackError, SnapSkipError };
+export { SnapProvider, SnapApiError, SnapUnavailableError, SnapFallbackError, SnapSkipError, isLocalBaseUrl };

--- a/lib/snap-provider.mjs
+++ b/lib/snap-provider.mjs
@@ -3,11 +3,12 @@
 import crypto from 'node:crypto';
 import fs from 'node:fs/promises';
 import fsSync from 'node:fs';
+import net from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
 
 import { makeMarkdown, buildReportCommentBody } from '@snapdrift/adapter-report-md';
-import { loadSnapdriftConfig } from '@snapdrift/adapter-fs';
+import { loadSnapdriftConfig, runBaselineCapture } from '@snapdrift/adapter-fs';
 import { selectConfiguredRoutes, splitCommaList, determineDriftStatus, VIEWPORT_PRESETS } from '@snapdrift/manifest';
 
 /** @typedef {import('../types/visual-diff-types').VisualProvider} VisualProvider */
@@ -31,6 +32,32 @@ const POLL_INTERVAL_MS = 2000;
 const MAX_POLL_DURATION_MS = 10 * 60 * 1000;
 
 const TERMINAL_RUN_STATUSES = new Set(['pass', 'fail', 'error']);
+
+/**
+ * @param {string | undefined} baseUrl
+ * @returns {boolean}
+ */
+export function isLocalBaseUrl(baseUrl) {
+  if (!baseUrl) {
+    return false;
+  }
+
+  let hostname;
+  try {
+    hostname = new URL(baseUrl).hostname.toLowerCase();
+  } catch {
+    return false;
+  }
+
+  const normalized = hostname.replace(/^\[/, '').replace(/\]$/, '');
+  if (normalized === 'localhost' || normalized.endsWith('.localhost')) {
+    return true;
+  }
+  if (normalized === '::1' || normalized === '0.0.0.0') {
+    return true;
+  }
+  return net.isIP(normalized) === 4 && normalized.startsWith('127.');
+}
 
 /**
  * @param {string} repoSlug
@@ -67,6 +94,8 @@ export class SnapProvider {
   #fetchFn;
   /** @type {(ms: number) => Promise<void>} */
   #sleepFn;
+  /** @type {(options?: { configPath?: string, routeIds?: Iterable<string>, outDir?: string }) => Promise<CaptureResult>} */
+  #localCaptureFn;
   /** @type {string} */
   #apiKey;
   /** @type {string} */
@@ -76,12 +105,17 @@ export class SnapProvider {
 
   /**
    * @param {SnapConfig} snapConfig — validated snap section from config
-   * @param {{ fetchFn?: typeof globalThis.fetch, sleepFn?: (ms: number) => Promise<void> }} [options]
+   * @param {{
+   *   fetchFn?: typeof globalThis.fetch,
+   *   sleepFn?: (ms: number) => Promise<void>,
+   *   localCaptureFn?: (options?: { configPath?: string, routeIds?: Iterable<string>, outDir?: string }) => Promise<CaptureResult>
+   * }} [options]
    */
   constructor(snapConfig, options = {}) {
     this.#snapConfig = snapConfig;
     this.#fetchFn = options.fetchFn ?? globalThis.fetch;
     this.#sleepFn = options.sleepFn ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
+    this.#localCaptureFn = options.localCaptureFn ?? runBaselineCapture;
     this.#apiUrl = (snapConfig.apiUrl || DEFAULT_API_URL).replace(/\/+$/, '');
     this.#apiKey = this.#resolveApiKey(snapConfig);
     this.#projectId = this.#resolveProjectId(snapConfig);
@@ -107,6 +141,17 @@ export class SnapProvider {
       ? [...options.routeIds]
       : splitCommaList(process.env.SNAPDRIFT_ROUTE_IDS);
     const { routes, selectedRouteIds } = selectConfiguredRoutes(config, requestedRouteIds);
+
+    if (isLocalBaseUrl(config.baseUrl)) {
+      return this.#captureLocalAndUpload({
+        configPath: options.configPath,
+        routeIds: requestedRouteIds,
+        outDir: options.outDir,
+        config,
+        routes,
+        selectedRouteIds
+      });
+    }
 
     const idempotencyKey = this.#generateIdempotencyKey();
     const runId = `run_${crypto.randomUUID().replace(/-/g, '').slice(0, 24)}`;
@@ -572,6 +617,80 @@ export class SnapProvider {
    */
   #generateIdempotencyKey() {
     return crypto.randomUUID();
+  }
+
+  /**
+   * @param {{
+   *   configPath?: string,
+   *   routeIds: string[],
+   *   outDir?: string,
+   *   config: VisualRegressionConfig,
+   *   routes: VisualRegressionConfig['routes'],
+   *   selectedRouteIds: string[]
+   * }} options
+   * @returns {Promise<CaptureResult>}
+   */
+  async #captureLocalAndUpload(options) {
+    const localCapture = await this.#localCaptureFn({
+      configPath: options.configPath,
+      routeIds: options.routeIds,
+      outDir: options.outDir
+    });
+
+    const runId = `run_${crypto.randomUUID().replace(/-/g, '').slice(0, 24)}`;
+    const baselineId = await this.#resolveLatestBaselineId();
+
+    await this.#request('POST', `/v1/visual/projects/${this.#projectId}/runs`, {
+      id: runId,
+      baseUrl: options.config.baseUrl,
+      trigger: 'ci',
+      ...(baselineId ? { baselineId } : {}),
+      ...this.#gitRunContext()
+    }, this.#generateIdempotencyKey());
+
+    const localResults = JSON.parse(await fs.readFile(localCapture.resultsPath, 'utf-8'));
+    const manifest = JSON.parse(await fs.readFile(localCapture.manifestPath, 'utf-8'));
+    const manifestById = new Map((manifest.screenshots || []).map((entry) => [entry.id, entry]));
+
+    for (const route of options.routes) {
+      const manifestEntry = manifestById.get(route.id);
+      if (!manifestEntry) {
+        throw new Error(`Local Snap capture did not produce a screenshot for route "${route.id}".`);
+      }
+
+      const captureId = `cap_${crypto.randomUUID().replace(/-/g, '').slice(0, 24)}`;
+      const viewportDescriptor = typeof route.viewport === 'string'
+        ? (VIEWPORT_PRESETS[route.viewport] ?? { width: 1280, height: 720 })
+        : route.viewport;
+
+      await this.#request('POST', `/v1/visual/runs/${runId}/captures`, {
+        id: captureId,
+        routeId: route.id,
+        routePath: route.path,
+        viewportDescriptorJson: JSON.stringify(viewportDescriptor),
+      }, this.#generateIdempotencyKey());
+
+      const imagePath = path.resolve(localCapture.screenshotsRoot, manifestEntry.imagePath);
+      const imageBytes = await fs.readFile(imagePath);
+
+      await this.#request('POST', `/v1/visual/captures/${captureId}/local-result`, {
+        imageBase64: imageBytes.toString('base64'),
+        width: manifestEntry.width,
+        height: manifestEntry.height
+      }, this.#generateIdempotencyKey());
+    }
+
+    const snapResults = {
+      ...localResults,
+      provider: 'snap',
+      captureMode: 'local-upload',
+      runId,
+      projectId: this.#projectId,
+      snapStartedAt: new Date().toISOString()
+    };
+    await fs.writeFile(localCapture.resultsPath, JSON.stringify(snapResults, null, 2));
+
+    return localCapture;
   }
 
   /**

--- a/lib/snap-provider.mjs
+++ b/lib/snap-provider.mjs
@@ -637,6 +637,23 @@ export class SnapProvider {
       outDir: options.outDir
     });
 
+    const localResults = JSON.parse(await fs.readFile(localCapture.resultsPath, 'utf-8'));
+    const manifest = JSON.parse(await fs.readFile(localCapture.manifestPath, 'utf-8'));
+    // Route ids are unique per the v1 schema (one viewport per route), so keying
+    // the manifest by id is an unambiguous join against the configured routes.
+    const manifestById = new Map((manifest.screenshots || []).map((entry) => [entry.id, entry]));
+
+    // Resolve every selected route to its screenshot up front, before any server
+    // call. A missing local capture then fails fast instead of leaving an
+    // orphaned run on Snap that can never complete.
+    const uploads = options.routes.map((route) => {
+      const manifestEntry = manifestById.get(route.id);
+      if (!manifestEntry) {
+        throw new Error(`Local Snap capture did not produce a screenshot for route "${route.id}".`);
+      }
+      return { route, manifestEntry };
+    });
+
     const runId = `run_${crypto.randomUUID().replace(/-/g, '').slice(0, 24)}`;
     const baselineId = await this.#resolveLatestBaselineId();
 
@@ -648,16 +665,7 @@ export class SnapProvider {
       ...this.#gitRunContext()
     }, this.#generateIdempotencyKey());
 
-    const localResults = JSON.parse(await fs.readFile(localCapture.resultsPath, 'utf-8'));
-    const manifest = JSON.parse(await fs.readFile(localCapture.manifestPath, 'utf-8'));
-    const manifestById = new Map((manifest.screenshots || []).map((entry) => [entry.id, entry]));
-
-    for (const route of options.routes) {
-      const manifestEntry = manifestById.get(route.id);
-      if (!manifestEntry) {
-        throw new Error(`Local Snap capture did not produce a screenshot for route "${route.id}".`);
-      }
-
+    for (const { route, manifestEntry } of uploads) {
       const captureId = `cap_${crypto.randomUUID().replace(/-/g, '').slice(0, 24)}`;
       const viewportDescriptor = typeof route.viewport === 'string'
         ? (VIEWPORT_PRESETS[route.viewport] ?? { width: 1280, height: 720 })

--- a/tests/snap-provider.test.js
+++ b/tests/snap-provider.test.js
@@ -351,6 +351,51 @@ describe('SnapProvider.capture()', () => {
       await fs.rm(tempDir, { recursive: true, force: true });
     }
   });
+
+  it('throws when local capture does not produce a selected route screenshot', async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'snapdrift-snap-local-missing-'));
+    const mockFetch = async (url) => {
+      if (url.includes('/baselines/latest')) {
+        return errorResponse(404, { error: 'no baseline' });
+      }
+      return okResponse({ id: 'run_abc123', status: 'pending', captures: [] });
+    };
+
+    const localCaptureFn = async () => {
+      const screenshotsRoot = path.join(tempDir, 'capture');
+      await fs.mkdir(screenshotsRoot, { recursive: true });
+      const resultsPath = path.join(screenshotsRoot, 'results.json');
+      const manifestPath = path.join(screenshotsRoot, 'manifest.json');
+      await fs.writeFile(resultsPath, JSON.stringify({ routes: [] }));
+      await fs.writeFile(manifestPath, JSON.stringify({ screenshots: [] }));
+      return {
+        resultsPath,
+        manifestPath,
+        screenshotsRoot,
+        selectedRouteIds: ['home']
+      };
+    };
+
+    const provider = new SnapProvider(validSnapConfig, { fetchFn: mockFetch, localCaptureFn });
+    const configPath = path.join(tempDir, 'snapdrift.json');
+    await fs.writeFile(configPath, JSON.stringify({
+      baselineArtifactName: 'test',
+      workingDirectory: '.',
+      baseUrl: 'http://127.0.0.1:3000',
+      resultsFile: 'results.json',
+      manifestFile: 'manifest.json',
+      screenshotsRoot: 'screenshots',
+      routes: [{ id: 'home', path: '/', viewport: 'desktop' }],
+      diff: { threshold: 0.01, mode: 'report-only' }
+    }));
+
+    try {
+      await expect(provider.capture({ configPath, routeIds: ['home'] }))
+        .rejects.toThrow(/did not produce a screenshot for route "home"/);
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/snap-provider.test.js
+++ b/tests/snap-provider.test.js
@@ -4,7 +4,7 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
-const { SnapProvider, SnapApiError, SnapUnavailableError, SnapFallbackError, SnapSkipError } = await import('../lib/snap-provider.mjs');
+const { SnapProvider, SnapApiError, SnapUnavailableError, SnapFallbackError, SnapSkipError, isLocalBaseUrl } = await import('../lib/snap-provider.mjs');
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -37,6 +37,21 @@ function errorResponse(status, errorBody) {
 // ---------------------------------------------------------------------------
 // SnapProvider construction
 // ---------------------------------------------------------------------------
+
+describe('isLocalBaseUrl()', () => {
+  it('detects loopback and localhost URLs only', () => {
+    expect(isLocalBaseUrl('http://localhost:3000')).toBe(true);
+    expect(isLocalBaseUrl('http://app.localhost:3000')).toBe(true);
+    expect(isLocalBaseUrl('http://127.0.0.1:3000')).toBe(true);
+    expect(isLocalBaseUrl('http://127.42.0.9:3000')).toBe(true);
+    expect(isLocalBaseUrl('http://[::1]:3000')).toBe(true);
+    expect(isLocalBaseUrl('http://0.0.0.0:3000')).toBe(true);
+
+    expect(isLocalBaseUrl('https://example.com')).toBe(false);
+    expect(isLocalBaseUrl('http://10.0.0.5:3000')).toBe(false);
+    expect(isLocalBaseUrl('not a url')).toBe(false);
+  });
+});
 
 describe('SnapProvider construction', () => {
   beforeEach(() => {
@@ -117,7 +132,7 @@ describe('SnapProvider.capture()', () => {
     const config = {
       baselineArtifactName: 'test',
       workingDirectory: '.',
-      baseUrl: 'http://localhost:3000',
+      baseUrl: 'https://example.com',
       resultsFile: 'results.json',
       manifestFile: 'manifest.json',
       screenshotsRoot: 'screenshots',
@@ -147,7 +162,7 @@ describe('SnapProvider.capture()', () => {
       // capture-profile comparison crash with a 500 when a baseline is attached.
       expect('captureProfileJson' in runPost.body).toBe(false);
       // baseUrl must be forwarded so the render worker knows what to render
-      expect(runPost.body.baseUrl).toBe('http://localhost:3000');
+      expect(runPost.body.baseUrl).toBe('https://example.com');
 
       // Verify capture POST
       const capturePost = requests.find((r) => r.url.includes('/captures'));
@@ -187,7 +202,7 @@ describe('SnapProvider.capture()', () => {
     const config = {
       baselineArtifactName: 'test',
       workingDirectory: '.',
-      baseUrl: 'http://localhost:3000',
+      baseUrl: 'https://example.com',
       resultsFile: 'results.json',
       manifestFile: 'manifest.json',
       screenshotsRoot: 'screenshots',
@@ -233,7 +248,7 @@ describe('SnapProvider.capture()', () => {
     const config = {
       baselineArtifactName: 'test',
       workingDirectory: '.',
-      baseUrl: 'http://localhost:3000',
+      baseUrl: 'https://example.com',
       resultsFile: 'results.json',
       manifestFile: 'manifest.json',
       screenshotsRoot: 'screenshots',
@@ -247,6 +262,93 @@ describe('SnapProvider.capture()', () => {
       expect('baselineId' in runPost.body).toBe(false);
     } finally {
       await fs.rm(configPath, { force: true });
+    }
+  });
+
+  it('captures loopback baseUrl locally and uploads current PNGs to Snap', async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'snapdrift-snap-local-'));
+    const requests = [];
+    const mockFetch = async (url, opts) => {
+      requests.push({ url, method: opts?.method, headers: opts?.headers, body: opts?.body ? JSON.parse(opts.body) : null });
+      if (url.includes('/baselines/latest')) {
+        return errorResponse(404, { error: 'no baseline' });
+      }
+      if (url.includes('/runs/') && url.includes('/captures')) {
+        return okResponse({ id: 'cap_1', status: 'pending' });
+      }
+      if (url.includes('/local-result')) {
+        return okResponse({ id: 'cap_1', status: 'rendered' });
+      }
+      return okResponse({ id: 'run_abc123', status: 'pending', captures: [] });
+    };
+
+    const localCaptureFn = async () => {
+      const screenshotsRoot = path.join(tempDir, 'capture');
+      const screenshotsDir = path.join(screenshotsRoot, 'screenshots');
+      await fs.mkdir(screenshotsDir, { recursive: true });
+      await fs.writeFile(path.join(screenshotsDir, 'home.png'), 'png-bytes');
+      const resultsPath = path.join(screenshotsRoot, 'results.json');
+      const manifestPath = path.join(screenshotsRoot, 'manifest.json');
+      await fs.writeFile(resultsPath, JSON.stringify({
+        baseUrl: 'http://127.0.0.1:3000',
+        routes: [{ id: 'home', status: 'passed', imagePath: 'screenshots/home.png' }]
+      }));
+      await fs.writeFile(manifestPath, JSON.stringify({
+        baseUrl: 'http://127.0.0.1:3000',
+        screenshots: [{
+          id: 'home',
+          path: '/',
+          viewport: 'desktop',
+          imagePath: 'screenshots/home.png',
+          width: 1440,
+          height: 900
+        }]
+      }));
+      return {
+        resultsPath,
+        manifestPath,
+        screenshotsRoot,
+        selectedRouteIds: ['home']
+      };
+    };
+
+    const provider = new SnapProvider(validSnapConfig, { fetchFn: mockFetch, localCaptureFn });
+    const configPath = path.join(tempDir, 'snapdrift.json');
+    const config = {
+      baselineArtifactName: 'test',
+      workingDirectory: '.',
+      baseUrl: 'http://127.0.0.1:3000',
+      resultsFile: 'results.json',
+      manifestFile: 'manifest.json',
+      screenshotsRoot: 'screenshots',
+      routes: [{ id: 'home', path: '/', viewport: 'desktop' }],
+      diff: { threshold: 0.01, mode: 'report-only' }
+    };
+    await fs.writeFile(configPath, JSON.stringify(config));
+
+    try {
+      const result = await provider.capture({ configPath, routeIds: ['home'] });
+      expect(result.selectedRouteIds).toEqual(['home']);
+
+      const runPost = requests.find((r) => r.url.includes('/runs') && !r.url.includes('/captures'));
+      expect(runPost.body.baseUrl).toBe('http://127.0.0.1:3000');
+      expect('captureProfileJson' in runPost.body).toBe(false);
+
+      const capturePost = requests.find((r) => r.url.includes('/runs/') && r.url.includes('/captures'));
+      expect(capturePost.body.routeId).toBe('home');
+
+      const uploadPost = requests.find((r) => r.url.includes('/local-result'));
+      expect(uploadPost).toBeDefined();
+      expect(uploadPost.body.imageBase64).toBe(Buffer.from('png-bytes').toString('base64'));
+      expect(uploadPost.body.width).toBe(1440);
+      expect(uploadPost.body.height).toBe(900);
+
+      const rewrittenResults = JSON.parse(await fs.readFile(result.resultsPath, 'utf-8'));
+      expect(rewrittenResults.provider).toBe('snap');
+      expect(rewrittenResults.captureMode).toBe('local-upload');
+      expect(rewrittenResults.runId).toMatch(/^run_/);
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
     }
   });
 });
@@ -286,7 +388,7 @@ describe('SnapProvider.diff() baseline mapping', () => {
     await fs.writeFile(configPath, JSON.stringify({
       baselineArtifactName: 'test',
       workingDirectory: '.',
-      baseUrl: 'http://localhost:3000',
+      baseUrl: 'https://example.com',
       resultsFile: 'results.json',
       manifestFile: 'manifest.json',
       screenshotsRoot: 'screenshots',

--- a/tests/snap-provider.test.js
+++ b/tests/snap-provider.test.js
@@ -354,7 +354,9 @@ describe('SnapProvider.capture()', () => {
 
   it('throws when local capture does not produce a selected route screenshot', async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'snapdrift-snap-local-missing-'));
-    const mockFetch = async (url) => {
+    const requests = [];
+    const mockFetch = async (url, opts) => {
+      requests.push({ url, method: opts?.method });
       if (url.includes('/baselines/latest')) {
         return errorResponse(404, { error: 'no baseline' });
       }
@@ -392,6 +394,12 @@ describe('SnapProvider.capture()', () => {
     try {
       await expect(provider.capture({ configPath, routeIds: ['home'] }))
         .rejects.toThrow(/did not produce a screenshot for route "home"/);
+
+      // Fail-fast guard: the missing screenshot must be detected before any run
+      // is created, so Snap is never left with an orphaned run.
+      const runCreatePost = requests.find((r) =>
+        r.method === 'POST' && /\/projects\/.+\/runs$/.test(r.url));
+      expect(runCreatePost).toBeUndefined();
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });
     }

--- a/tests/snapdrift-actions-contract.test.js
+++ b/tests/snapdrift-actions-contract.test.js
@@ -106,4 +106,22 @@ describe('SnapDrift action contracts', () => {
         expect(commentStep.with.script).toContain('createProvider');
         expect(commentStep.with.script).toContain('buildCommentBody');
     });
+
+    it('installs Playwright for Snap local-capture hybrid runs', async () => {
+        const baseline = await readAction('actions/baseline/action.yml');
+        const prDiff = await readAction('actions/pr-diff/action.yml');
+
+        const baselineConfig = baseline.runs.steps.find((step) => step.id === 'config');
+        const baselineInstall = baseline.runs.steps.find((step) => step.name === 'Install Playwright Chromium');
+        const prDiffConfig = prDiff.runs.steps.find((step) => step.id === 'config');
+        const prDiffInstall = prDiff.runs.steps.find((step) => step.name === 'Install Playwright Chromium');
+
+        expect(baselineConfig.run).toContain('isLocalBaseUrl(config.baseUrl)');
+        expect(baselineConfig.run).toContain('snap_local_capture=');
+        expect(baselineInstall.if).toContain("steps.config.outputs.snap_local_capture == 'true'");
+
+        expect(prDiffConfig.run).toContain('isLocalBaseUrl(config.baseUrl)');
+        expect(prDiffConfig.run).toContain('snap_local_capture=');
+        expect(prDiffInstall.if).toContain("steps.config.outputs.snap_local_capture == 'true'");
+    });
 });


### PR DESCRIPTION
## Summary
- `provider: "snap"` currently sends loopback `baseUrl` values to Snap Cloud, so cloud rendering captures the baseline/current from Snap's network instead of the consumer CI app.
- This adds automatic hybrid capture for local URLs: SnapDrift captures with local Playwright, uploads the PNGs into a Snap run, and keeps Snap Cloud responsible for dashboard storage and diff polling.
- Public URLs continue using the existing hosted Snap render path, and no new consumer config field is required.

## Changes
- Add loopback/local URL detection for `localhost`, `.localhost`, `127.0.0.0/8`, `::1`, and `0.0.0.0`.
- Update `SnapProvider.capture()` to branch between hosted Snap rendering and local Playwright capture plus Snap upload.
- Export the local URL detector for action runtime checks.
- Install Playwright Chromium in baseline and PR diff actions only when Snap provider uses a local `baseUrl` or fallback-local remains possible.
- Add unit/contract tests for URL detection, hosted Snap request preservation, hybrid upload behavior, and action Playwright conditions.

## Test plan
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run validate:actions`
- [x] `npm run lint`

## Dependency
- Requires backend support from https://github.com/i2Dev-com/snap/pull/528 to be deployed before consumer repos rely on `provider: "snap"` with a loopback `baseUrl`.