### PR TITLE
Prepare 0.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.5.0 - 2026-06-08
+
 ### Features
 
 - **Snap local-capture hybrid** — when `provider: "snap"` and `baseUrl` resolves to a local address (localhost, `127.0.0.0/8`, `::1`, `0.0.0.0`), Playwright now runs on the runner to render the page, and the resulting PNG is uploaded to Snap via `POST /v1/visual/captures/:id/local-result`. This makes it possible to point SnapDrift at a server only the runner can reach — the common case — without exposing the server to Snap's render worker. Captures are flagged with `localCapture: true` so Snap keeps them out of the render queue, and the output `results.json` records `provider: "snap"` plus `captureMode: "local-upload"`.
@@ -13,6 +15,10 @@
 - **Run-creation includes `branch` and `baselineId`** — `branch` is sent from `GITHUB_HEAD_REF` (PR source) or `GITHUB_REF_NAME` (push); `baselineId` is the latest accepted baseline for the project, so the backend can diff every capture. Without `baselineId` Snap short-circuits to `diffed` with no comparison data.
 - **4xx never falls back, even with `onUnavailable` set** — clarifies the contract: `onUnavailable` is consulted only after 5xx/network retries are exhausted, never on a 4xx (which is a configuration error, not an outage).
 - **`actions/pr-diff` no longer installs Playwright when `provider: "snap"` and the run won't need it** — gated on the same `isLocalBaseUrl` check the `baseline` action uses.
+
+### Infrastructure
+
+- **`@snapdrift/manifest` v1.2.0** — added the `ProviderCaptureOptions.purpose` type contract for baseline-publish versus diff captures.
 
 ## 0.4.0 - 2026-05-26
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,22 @@
 {
   "name": "snapdrift",
-  "version": "0.3.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "snapdrift",
-      "version": "0.3.0",
+      "version": "0.5.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"
       ],
       "dependencies": {
         "@snapdrift/adapter-fs": "^1.0.0",
-        "@snapdrift/adapter-report-md": "^1.0.0",
+        "@snapdrift/adapter-report-md": "^1.1.0",
         "@snapdrift/compare-core": "^1.0.0",
-        "@snapdrift/manifest": "^1.0.0",
+        "@snapdrift/manifest": "^1.2.0",
+        "js-yaml": "^4.1.0",
         "playwright": "^1.59.1",
         "pngjs": "^7.0.0"
       },
@@ -31,7 +32,6 @@
         "eslint": "^10.2.0",
         "globals": "^17.4.0",
         "jest": "^30.3.0",
-        "js-yaml": "^4.1.0",
         "typescript": "^6.0.2"
       },
       "engines": {
@@ -1884,7 +1884,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/babel-jest": {
@@ -3842,7 +3841,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -5270,7 +5268,7 @@
       "license": "MIT",
       "dependencies": {
         "@snapdrift/compare-core": "^1.0.0",
-        "@snapdrift/manifest": "^1.0.0",
+        "@snapdrift/manifest": "^1.1.0",
         "playwright": "^1.59.1",
         "pngjs": "^7.0.0"
       },
@@ -5280,7 +5278,7 @@
     },
     "packages/adapter-report-md": {
       "name": "@snapdrift/adapter-report-md",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "engines": {
         "node": ">=22"
@@ -5299,7 +5297,7 @@
     },
     "packages/manifest": {
       "name": "@snapdrift/manifest",
-      "version": "1.0.0",
+      "version": "1.2.0",
       "license": "MIT",
       "engines": {
         "node": ">=22"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snapdrift",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": false,
   "type": "module",
   "description": "SnapDrift captures, compares, and reports UI drift for Playwright-based app checks.",
@@ -98,7 +98,7 @@
     "@snapdrift/adapter-fs": "^1.0.0",
     "@snapdrift/adapter-report-md": "^1.1.0",
     "@snapdrift/compare-core": "^1.0.0",
-    "@snapdrift/manifest": "^1.1.0",
+    "@snapdrift/manifest": "^1.2.0",
     "js-yaml": "^4.1.0",
     "playwright": "^1.59.1",
     "pngjs": "^7.0.0"

--- a/packages/manifest/package.json
+++ b/packages/manifest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapdrift/manifest",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "SnapDrift manifest schema, validation, and indexing — pure, zero I/O",
   "type": "module",
   "main": "src/index.mjs",


### PR DESCRIPTION
## Summary
- Prepare the next SnapDrift release for the Snap provider fixes and local-capture hybrid work that has landed since `v0.4.0`.
- Cut the changelog to `0.5.0` so the existing unreleased notes become the release notes for the upcoming GitHub release.
- Bump `@snapdrift/manifest` to `1.2.0` because its published type contract changed with `ProviderCaptureOptions.purpose`.

## Changes
- Bump root `snapdrift` package version to `0.5.0`.
- Bump `@snapdrift/manifest` package version to `1.2.0` and update the root dependency range.
- Refresh `package-lock.json` so release metadata and workspace package versions match current manifests.
- Move the current changelog entries under `0.5.0 - 2026-06-08` and add the manifest package note.

## Test plan
- [x] `PATH="/Users/mdaliahsanrana/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" npm run ci`
- [x] Confirmed `npm pack --dry-run` reports `snapdrift@0.5.0`.
